### PR TITLE
V0.6.0 beta branch merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Features that are planned to be implemented in the future:
   - [x] Talents (Skills & Traits)
   - [x] Depot (Items & Currencies)
   - [x] Blueprints (Recipes)
-  - [ ] Odyssey (Quests)
+  - [x] Odyssey (Quests)
   - [ ] Phrase Maps
 - [ ] **Core:** Implement an automatic [mod loader](#modding)
 - [ ] **Discourse:** Import/Export CSV files for localization

--- a/addons/nexus_forge/characters/characters_main_script.gd
+++ b/addons/nexus_forge/characters/characters_main_script.gd
@@ -1728,7 +1728,7 @@ func _parse_value(value: String, fallback: float) -> float:
 
 func _notification(what: int) -> void:
 	if what == NOTIFICATION_PREDELETE:
-		if undo != null and is_instance_valid(undo):
+		if is_instance_valid(undo):
 			undo.clear_history()
 			undo.free()
 			undo = null

--- a/addons/nexus_forge/classes/autoload/nexus_forge_singleton.gd
+++ b/addons/nexus_forge/classes/autoload/nexus_forge_singleton.gd
@@ -221,11 +221,11 @@ const _SETTINGS_PATHS: Dictionary[String, Dictionary] = {
 
 ## The dialog parser in charge of loading dialogs.[br]
 ## The object notifies of dialog data and events through signals.
-var Discourse: DialogParser
+var Discourse: NFDialogParser
 ## An object containing globally-accessible variables.[br]
 ## The variables are nested into a folder-like structure which can also contain
 ## folders.
-var Blackboard: BlackboardData
+var Blackboard: NFBlackboardData
 
 ## An object for registering and loading [CharacterSheet]s and applying
 ## modifications to them.
@@ -242,7 +242,7 @@ var Skills: NFSkillManager
 ## A resource containing the game's species data.
 var Species: NFSpeciesManager
 ## A resource containing the game's quests data.
-var Quests: QuestManager
+var Quests: NFQuestManager
 ## A resource containing the game's currency data and helper methods to manage
 ## different currency systems.
 var Currency: NFCurrencyManager
@@ -293,7 +293,7 @@ func _ready() -> void:
 			get_setting_path("variables"), "")
 	if not blackboard_path.is_empty() and ResourceLoader.exists(blackboard_path):
 		var res_pre: Resource = load(blackboard_path)
-		if res_pre is BlackboardData:
+		if res_pre is NFBlackboardData:
 			Blackboard = res_pre
 		else:
 			_log_msg(
@@ -390,12 +390,12 @@ func _ready() -> void:
 	
 	if Discourse == null:
 		if instantiate_disabled or use_discourse:
-			Discourse = EditorDialogParser.new() if OS.has_feature("editor") else DialogParser.new()
+			Discourse = NFEditorDialogParser.new() if OS.has_feature("editor") else NFDialogParser.new()
 			if use_discourse:
 				Discourse.generate_locale_map()
 
 	if Blackboard == null:
-		Blackboard = BlackboardData.new()
+		Blackboard = NFBlackboardData.new()
 	
 	if Stats == null and instantiate_disabled:
 		Stats = NFStatManager.new()
@@ -439,7 +439,7 @@ func _ready() -> void:
 									"Failed to load NexusForge settings",
 									NFPluginGameHandler._LogLevel.WARNING)
 	if Quests == null and ( use_quests or instantiate_disabled ):
-		Quests = QuestManager.new()
+		Quests = NFQuestManager.new()
 	if Species == null and instantiate_disabled:
 		Species = NFSpeciesManager.new()
 	if Items == null and instantiate_disabled:

--- a/addons/nexus_forge/classes/simple_data_tree.gd
+++ b/addons/nexus_forge/classes/simple_data_tree.gd
@@ -526,10 +526,6 @@ func _do_update_item_data(path: String, data: Variant) -> void:
 	var new_type: int = _data_type_to_internal(typeof(data))
 	
 	if new_type != item.get_metadata(1):
-		if item.get_metadata(1) == TYPE_DICTIONARY:
-			var btn_idx: int = item.get_button_by_id(1, ButtonIds.TYPE_MENU)
-			if btn_idx != -1:
-				item.erase_button(1, btn_idx)
 		match new_type:
 			TYPE_INT:
 				item.set_icon(0, ICON_INT)
@@ -765,7 +761,8 @@ func on_data_edited() -> void:
 		var emit_update: bool = true
 		match edited.get_metadata(1):
 			TYPE_INT, TYPE_FLOAT:
-				if edited.get_metadata(0)["value"] != int(edited.get_range(1)) if edited.get_metadata(1) == TYPE_INT else edited.get_range(1):
+				var current_val = int(edited.get_range(1)) if edited.get_metadata(1) == TYPE_INT else edited.get_range(1)
+				if edited.get_metadata(0)["value"] != current_val:
 					edited.get_metadata(0)["value"] = to
 				else:
 					emit_update = false

--- a/addons/nexus_forge/depot/depot_main_script.gd
+++ b/addons/nexus_forge/depot/depot_main_script.gd
@@ -173,8 +173,11 @@ func save() -> void:
 
 func _notification(what: int) -> void:
 	if what == NOTIFICATION_PREDELETE:
-		if categories_container.category_undo != null and is_instance_valid(categories_container.category_undo):
+		if is_instance_valid(categories_container) and is_instance_valid(categories_container.category_undo):
+			categories_container.category_undo.clear_history()
 			categories_container.category_undo.free()
 			categories_container.category_undo = null
-		if items_container.undo != null and is_instance_valid(items_container.undo):
+		if is_instance_valid(items_container) and is_instance_valid(items_container.undo):
+			items_container.undo.clear_history()
 			items_container.undo.free()
+			items_container.undo = null

--- a/addons/nexus_forge/depot/items_script.gd
+++ b/addons/nexus_forge/depot/items_script.gd
@@ -722,6 +722,9 @@ func _do_rename_currency(currency_id: StringName, new_name: String) -> void:
 
 
 func _on_item_description_focus_exited() -> void:
+	if not item_desc_txt_edt.editable:
+		return
+	
 	var old_desc: String = item_desc_txt_edt.get_meta(&"old_value")
 	
 	if item_desc_txt_edt.text == old_desc:

--- a/addons/nexus_forge/discourse/dialog_previewer.gd
+++ b/addons/nexus_forge/discourse/dialog_previewer.gd
@@ -28,7 +28,7 @@ func _ready() -> void:
 	var success: bool = false
 	
 	if NexusForge.Discourse == null:
-		NexusForge.Discourse = EditorDialogParser.new()
+		NexusForge.Discourse = NFEditorDialogParser.new()
 	
 	var empty_path: bool = false
 	var empty_locale: bool = false

--- a/addons/nexus_forge/discourse/discourse_graph_edit_new.gd
+++ b/addons/nexus_forge/discourse/discourse_graph_edit_new.gd
@@ -29,7 +29,7 @@ signal browse_character_requested(target_control: LineEdit)
 signal paste_nodes_requested
 
 # Enum to differentiate dialog nodes
-const DialogNodes = DialogParser.NodeTypes
+const DialogNodes = NFDialogParser.NodeTypes
 # Enum to differentiate connection types
 const ConnectionType = DiscourseGraphNode.SlotConnectionType
 # Enum to differentiate port directions

--- a/addons/nexus_forge/discourse/discourse_nodes_tree.gd
+++ b/addons/nexus_forge/discourse/discourse_nodes_tree.gd
@@ -19,42 +19,42 @@ const DIALOG_COLOR: Color = Color(0.553, 0.647, 0.953)
 const SETTINGS_COLOR: Color = Color(0.99, 0.808, 0.495)
 const RESOURCE_COLOR: Color = Color(0.988, 0.498, 0.498)
 
-const DIALOG: Array[DialogParser.NodeTypes] = [
-		DialogParser.NodeTypes.ENTRY,
-		DialogParser.NodeTypes.DIALOG,
-		DialogParser.NodeTypes.CHOICES,
-		DialogParser.NodeTypes.BRANCH,
-		DialogParser.NodeTypes.COMPARATION,
-		DialogParser.NodeTypes.EVENT,
-		DialogParser.NodeTypes.MATCH,
-		DialogParser.NodeTypes.PAUSE,
-		DialogParser.NodeTypes.RANDOM,
-		DialogParser.NodeTypes.ANCHOR_POINTER,
-		DialogParser.NodeTypes.ANCHOR,
-		DialogParser.NodeTypes.DIALOG_END,
-		DialogParser.NodeTypes.DIALOG_MERGE,
-		DialogParser.NodeTypes.LOCALIZED_TEXT]
+const DIALOG: Array[NFDialogParser.NodeTypes] = [
+		NFDialogParser.NodeTypes.ENTRY,
+		NFDialogParser.NodeTypes.DIALOG,
+		NFDialogParser.NodeTypes.CHOICES,
+		NFDialogParser.NodeTypes.BRANCH,
+		NFDialogParser.NodeTypes.COMPARATION,
+		NFDialogParser.NodeTypes.EVENT,
+		NFDialogParser.NodeTypes.MATCH,
+		NFDialogParser.NodeTypes.PAUSE,
+		NFDialogParser.NodeTypes.RANDOM,
+		NFDialogParser.NodeTypes.ANCHOR_POINTER,
+		NFDialogParser.NodeTypes.ANCHOR,
+		NFDialogParser.NodeTypes.DIALOG_END,
+		NFDialogParser.NodeTypes.DIALOG_MERGE,
+		NFDialogParser.NodeTypes.LOCALIZED_TEXT]
 	
-const DATA: Array[DialogParser.NodeTypes] = [
-		DialogParser.NodeTypes.CONDITION_SELECT,
-		DialogParser.NodeTypes.TYPE_GUARD,
-		DialogParser.NodeTypes.VALUE,
-		DialogParser.NodeTypes.SIGNAL,
-		DialogParser.NodeTypes.CALLABLE,
-		DialogParser.NodeTypes.CALLABLE_RETURN,
-		DialogParser.NodeTypes.VARIABLE_GET,
-		DialogParser.NodeTypes.RANDOM_VALUE,
-		DialogParser.NodeTypes.DATA_EVENT,
-		DialogParser.NodeTypes.LOCALIZED_TEXT,
-		DialogParser.NodeTypes.METADATA]
+const DATA: Array[NFDialogParser.NodeTypes] = [
+		NFDialogParser.NodeTypes.CONDITION_SELECT,
+		NFDialogParser.NodeTypes.TYPE_GUARD,
+		NFDialogParser.NodeTypes.VALUE,
+		NFDialogParser.NodeTypes.SIGNAL,
+		NFDialogParser.NodeTypes.CALLABLE,
+		NFDialogParser.NodeTypes.CALLABLE_RETURN,
+		NFDialogParser.NodeTypes.VARIABLE_GET,
+		NFDialogParser.NodeTypes.RANDOM_VALUE,
+		NFDialogParser.NodeTypes.DATA_EVENT,
+		NFDialogParser.NodeTypes.LOCALIZED_TEXT,
+		NFDialogParser.NodeTypes.METADATA]
 	
-const SETTINGS: Array[DialogParser.NodeTypes] = [
-		DialogParser.NodeTypes.SETTINGS_CHARACTER,
-		DialogParser.NodeTypes.SETTINGS_DIALOG,
-		DialogParser.NodeTypes.SETTINGS_OPTION]
+const SETTINGS: Array[NFDialogParser.NodeTypes] = [
+		NFDialogParser.NodeTypes.SETTINGS_CHARACTER,
+		NFDialogParser.NodeTypes.SETTINGS_DIALOG,
+		NFDialogParser.NodeTypes.SETTINGS_OPTION]
 	
-const RESOURCES: Array[DialogParser.NodeTypes] = [
-		DialogParser.NodeTypes.RESOURCE]
+const RESOURCES: Array[NFDialogParser.NodeTypes] = [
+		NFDialogParser.NodeTypes.RESOURCE]
 
 var nodes: Dictionary[StringName, TreeItem] = {}
 

--- a/addons/nexus_forge/discourse/nodes/base.gd
+++ b/addons/nexus_forge/discourse/nodes/base.gd
@@ -79,6 +79,14 @@ var _input_nodes: Array[Dictionary] = []
 var _output_nodes: Array[Dictionary] = []
 
 
+static func _static_init() -> void:
+	var all_classes: Array[Dictionary] = ProjectSettings.get_global_class_list()
+	for class_entry in all_classes:
+		if class_entry["class"] == "DiscourseAPI":
+			api_path = class_entry["path"]
+			break
+
+
 func _init(uuid: StringName = &"", theme_variant: StringName = &"", with_duplicate: bool = true, with_close: bool = true, localization: bool = false) -> void:
 	_uuid = StringName(UUID.generate_new()) if uuid.is_empty() else uuid
 	var _hbox: HBoxContainer = get_titlebar_hbox()

--- a/addons/nexus_forge/discourse/nodes/base.gd
+++ b/addons/nexus_forge/discourse/nodes/base.gd
@@ -39,7 +39,7 @@ enum IssueLevel {
 	ERROR = 0,
 	WARNING = 1}
 
-const DialogueNodeType := DialogParser.NodeTypes
+const DialogueNodeType := NFDialogParser.NodeTypes
 
 const COLORS: Dictionary = {
 	"dialog": Color.SEA_GREEN,

--- a/addons/nexus_forge/discourse/nodes/random_select.gd
+++ b/addons/nexus_forge/discourse/nodes/random_select.gd
@@ -14,7 +14,7 @@ func update_weights() -> void:
 		for node in range(2, get_child_count()):
 			get_child(node).get_child(1).text = "Weight ??.??%"
 	else:
-		var base_weight: int = DialogParser.RANDOM_DEFAULT_WEIGHT if custom_default_weight < 0 else custom_default_weight
+		var base_weight: int = NFDialogParser.RANDOM_DEFAULT_WEIGHT if custom_default_weight < 0 else custom_default_weight
 		var total_weight: int = 0
 		var weights: Array[int] = []
 		var labels: Array[Label] = []

--- a/addons/nexus_forge/export_plugin.gd
+++ b/addons/nexus_forge/export_plugin.gd
@@ -24,6 +24,7 @@ var quest_ids: Dictionary[StringName, String] = {}
 var export_characters: bool = true
 
 var added_files: Dictionary[String, Variant] = {}
+var discourse_api_methods: Dictionary[StringName, Dictionary] = {}
 
 
 func _get_name() -> String:
@@ -31,18 +32,33 @@ func _get_name() -> String:
 
 
 func _export_begin(_features: PackedStringArray, _is_debug: bool, _path: String, _flags: int) -> void:
+	clear_memory()
+	
+	var discourse_api_found: bool = false
+	var api_path: String = ""
+	
+	var all_classes: Array[Dictionary] = ProjectSettings.get_global_class_list()
+	for class_entry in all_classes:
+		if class_entry["class"] == "DiscourseAPI":
+			api_path = class_entry["path"]
+			break
+	
+	if not api_path.is_empty():
+		var api_script: Script = load(api_path)
+		if api_script != null:
+			for method in api_script.get_script_method_list():
+				discourse_api_methods[StringName(method["name"])] = method
+			discourse_api_found = true
+	
+	if not discourse_api_found:
+		NFPluginGameHandler._log_msg(
+				"export",
+				"Couldn't locate DiscourseAPI script file.",
+				NFPluginGameHandler._LogLevel.ERROR)
+	
 	export_temp_dir = DirAccess.create_temp("godot_nf_plugin")
 	var file_base_path: String = ProjectSettings.get_setting(
 			NFPluginGameHandler.get_setting_path("discourse")).strip_edges()
-	
-	release_files.clear()
-	localization_groups.clear()
-	localization_files.clear()
-	dialog_file_to_id.clear()
-	id_to_localization.clear()
-	character_ids.clear()
-	quest_ids.clear()
-	added_files.clear()
 	
 	export_characters = ProjectSettings.get_setting(
 			NFPluginGameHandler.get_setting_path("characters_id_to_files"),
@@ -246,7 +262,7 @@ func _end_customize_resources() -> void:
 
 
 func process_editor_discourse_dialog(dialog_resource: EditorDiscourseDialog, dialog_id: String, expected_name: String) -> DiscourseDialog:
-	var release_resource: DiscourseDialog = dialog_resource.convert_for_release()
+	var release_resource: DiscourseDialog = dialog_resource.convert_for_release(discourse_api_methods)
 	
 	var localizations: Array[Dictionary] = dialog_resource.generate_localization_files(dialog_id, dialog_path, expected_name, localization_groups)
 	
@@ -317,7 +333,10 @@ func customize_skill_catalog(catalog: SkillCatalog) -> SkillCatalog:
 
 func _export_end() -> void:
 	export_temp_dir = null
-	
+	clear_memory()
+
+
+func clear_memory() -> void:
 	release_files.clear()
 	localization_groups.clear()
 	localization_files.clear()
@@ -326,3 +345,4 @@ func _export_end() -> void:
 	character_ids.clear()
 	quest_ids.clear()
 	added_files.clear()
+	discourse_api_methods.clear()

--- a/addons/nexus_forge/nexus_forge_main_scene_script.gd
+++ b/addons/nexus_forge/nexus_forge_main_scene_script.gd
@@ -140,7 +140,7 @@ func _get_variables_for(path: String) -> Array[Dictionary]:
 	if variables._variables_resource == null:
 		return paths
 	
-	var data: BlackboardData = variables._variables_resource
+	var data: NFBlackboardData = variables._variables_resource
 	
 	for folder_path in data.folders():
 		if folder_path.begins_with(path):

--- a/addons/nexus_forge/plugin.cfg
+++ b/addons/nexus_forge/plugin.cfg
@@ -3,5 +3,5 @@
 name="Nexus Forge"
 description="A headless modular toolset plugin for Godot"
 author="Ketei"
-version="0.5.2-beta"
+version="0.6.0-beta"
 script="plugin.gd"

--- a/addons/nexus_forge/plugin.gd
+++ b/addons/nexus_forge/plugin.gd
@@ -687,7 +687,7 @@ func _on_resource_removed(object: Resource) -> void:
 		editor_view.phrase_maps.filesystem_resource_removed(object)
 	elif object is Quest:
 		editor_view.quests.filesystem_resource_removed(object)
-	elif object is BlackboardData:
+	elif object is NFBlackboardData:
 		if editor_view.variables._variables_resource == object:
 			ProjectSettings.set_setting(
 					NFPluginGameHandler.get_setting_path("variables"),

--- a/addons/nexus_forge/quests/events_tree.gd
+++ b/addons/nexus_forge/quests/events_tree.gd
@@ -136,7 +136,7 @@ func _on_compact_menu_id_pressed(id: int) -> void:
 	else:
 		data_name += "data"
 	
-	var path: String = add_data(data_name, data_type, false, data_item)
+	var path: String = add_data(data_name, data_type, data_item)
 	
 	data_item = null
 	
@@ -147,7 +147,7 @@ func _get_drag_data(at_position: Vector2) -> Variant:
 	if not allow_drag_and_drop:
 		return null
 	var item: TreeItem = get_item_at_position(at_position)
-	if item == null:
+	if item == null or item.get_parent() == get_root():
 		return null
 	var preview: Label = Label.new()
 	preview.text = "    " + item.get_text(0)
@@ -165,12 +165,13 @@ func _can_drop_data(at_position: Vector2, data: Variant) -> bool:
 	
 	if data.has_all(["tree", "type", "source"]) and typeof(data["source"]) == TYPE_STRING and data["source"] == "data_tree":
 		var target_node: TreeItem = get_item_at_position(at_position)
-		if target_node == data["tree"] or (data["type"] == ItemType.FOLDER and _is_item_child_of(target_node, data["tree"])): #target_node.get_parent() == data["tree"]):
+		if target_node == null:
 			drop_mode_flags = DROP_MODE_DISABLED
 			return false
 		
-		if target_node == null:
-			return true
+		if target_node == data["tree"] or (data["type"] == ItemType.FOLDER and _is_item_child_of(target_node, data["tree"])):
+			drop_mode_flags = DROP_MODE_DISABLED
+			return false
 		
 		if target_node.get_metadata(0)["type"] == ItemType.FOLDER:
 			drop_mode_flags = DROP_MODE_ON_ITEM + DROP_MODE_INBETWEEN
@@ -486,10 +487,6 @@ func _do_update_item_data(path: String, data: Variant) -> void:
 	var new_type: int = _data_type_to_internal(typeof(data))
 	
 	if new_type != item.get_metadata(1):
-		if item.get_metadata(1) == TYPE_DICTIONARY:
-			var btn_idx: int = item.get_button_by_id(1, ButtonIds.TYPE_MENU)
-			if btn_idx != -1:
-				item.erase_button(1, btn_idx)
 		match new_type:
 			TYPE_INT:
 				item.set_icon(0, ICON_INT)
@@ -539,7 +536,10 @@ func _do_update_item_data(path: String, data: Variant) -> void:
 					item.add_button(1, preload("res://addons/nexus_forge/icons/add_string.svg"), ButtonIds.STRING, false, "Add String")
 					item.add_button(1, get_theme_icon("FolderCreate", "EditorIcons"), ButtonIds.LEVEL, false, "Add Level")
 				for subdata in data:
-					add_data(subdata, data[subdata], false, item)
+					_add_data_to_tree(
+						subdata,
+						data[subdata],
+						item)
 			_:
 				item.set_icon(0, ICON_VARIABLE)
 				item.set_metadata(1, TYPE_NIL)
@@ -561,16 +561,9 @@ func _do_update_item_data(path: String, data: Variant) -> void:
 	item.get_metadata(0)["value"] = data
 
 
-func add_data(data_id: String, data: Variant, initial_load: bool = false, on_node: TreeItem = get_root()) -> String:
+func add_data(data_id: String, data: Variant, on_node: TreeItem = get_root()) -> String:
 	var new_name: String = get_unique_id(on_node, data_id)
 	var data_path: String = _get_data_path(on_node).path_join(new_name)
-	
-	if initial_load:
-		_add_data_to_tree(
-				new_name,
-				data,
-				on_node)
-		return data_path
 	
 	var type: int = typeof(data)
 	
@@ -656,7 +649,7 @@ func _add_data_to_tree(new_name: String, data: Variant, on_node: TreeItem = get_
 
 func add_constant_data(new_name: String, data: Variant, on_node: TreeItem = get_root(), index: int = -1) -> void:
 	var valid_name: String = get_unique_id(on_node, new_name)
-	var data_tree: TreeItem = _add_data_to_tree(new_name, data, on_node, index)
+	var data_tree: TreeItem = _add_data_to_tree(valid_name, data, on_node, index)
 	data_tree.erase_button(
 			1,
 			data_tree.get_button_by_id(1, ButtonIds.DELETE))
@@ -701,19 +694,19 @@ func _on_button_clicked(item: TreeItem, column: int, id: int, mouse_button_index
 			return
 		ButtonIds.INT:
 			data_copy = 0
-			data_path = add_data("new_int", 0, false, item)
+			data_path = add_data("new_int", 0, item)
 		ButtonIds.FLOAT:
 			data_copy = 0.0
-			data_path = add_data("new_float", 0.0, false, item)
+			data_path = add_data("new_float", 0.0, item)
 		ButtonIds.BOOL:
 			data_copy = false
-			data_path = add_data("new_bool", false, false, item)
+			data_path = add_data("new_bool", false, item)
 		ButtonIds.STRING:
 			data_copy = ""
-			data_path = add_data("new_string", "", false, item)
+			data_path = add_data("new_string", "", item)
 		ButtonIds.LEVEL:
 			data_copy = {}
-			data_path = add_data("new_folder", {}, false, item)
+			data_path = add_data("new_folder", {}, item)
 		ButtonIds.TYPE_MENU:
 			data_item = item
 			mn.position = DisplayServer.mouse_get_position()
@@ -736,7 +729,8 @@ func on_data_edited() -> void:
 		
 		match edited.get_metadata(1):
 			TYPE_INT, TYPE_FLOAT:
-				if edited.get_metadata(0)["value"] != int(edited.get_range(1)) if edited.get_metadata(1) == TYPE_INT else edited.get_range(1):
+				var current_val = int(edited.get_range(1)) if edited.get_metadata(1) == TYPE_INT else edited.get_range(1)
+				if edited.get_metadata(0)["value"] != current_val:
 					edited.get_metadata(0)["value"] = to
 				else:
 					emit_update = false

--- a/addons/nexus_forge/quests/events_tree.gd
+++ b/addons/nexus_forge/quests/events_tree.gd
@@ -2,8 +2,11 @@
 extends IDTree
 
 
-signal item_deleted
-signal data_changed
+signal data_created(path: String, index: int ,data: Variant)
+signal data_moved(from_path: String, from_index: int, to_path: String, to_index: int)
+signal data_renamed(parent_path: String, old_name: String, new_name: String)
+signal data_updated(path: String, old_value: Variant, new_value: Variant)
+signal data_erased(path: String, index: int, data: Variant)
 
 enum ItemType {
 	DATA,
@@ -20,7 +23,8 @@ enum ButtonIds {
 	TYPE_MENU,
 }
 
-const RANGE_MAX: int = 9999
+const RANGE_CEIL: int = 9999
+const RANGE_FLOOR: int = -9999
 const RANGE_FLOAT_STEP: float = 0.01
 
 @export var allow_drag_and_drop: bool = false
@@ -53,6 +57,7 @@ func ready_plugin() -> void:
 	id_cell = 0
 	
 	create_item()
+	
 	set_column_title(0, "Data ID")
 	set_column_title(1, "Data Value")
 	
@@ -131,18 +136,18 @@ func _on_compact_menu_id_pressed(id: int) -> void:
 	else:
 		data_name += "data"
 	
-	add_data(data_name, data_type, data_item)
+	var path: String = add_data(data_name, data_type, false, data_item)
 	
 	data_item = null
 	
-	data_changed.emit()
+	data_created.emit(path, -1, data_type)
 
 
 func _get_drag_data(at_position: Vector2) -> Variant:
 	if not allow_drag_and_drop:
 		return null
 	var item: TreeItem = get_item_at_position(at_position)
-	if item == null or item.get_parent() == get_root():
+	if item == null:
 		return null
 	var preview: Label = Label.new()
 	preview.text = "    " + item.get_text(0)
@@ -165,11 +170,9 @@ func _can_drop_data(at_position: Vector2, data: Variant) -> bool:
 			return false
 		
 		if target_node == null:
-			return false
+			return true
 		
-		if target_node.get_parent() == get_root():
-			drop_mode_flags = DROP_MODE_ON_ITEM
-		elif target_node.get_metadata(0)["type"] == ItemType.FOLDER:
+		if target_node.get_metadata(0)["type"] == ItemType.FOLDER:
 			drop_mode_flags = DROP_MODE_ON_ITEM + DROP_MODE_INBETWEEN
 		else:
 			drop_mode_flags = DROP_MODE_INBETWEEN
@@ -192,36 +195,145 @@ func _is_item_child_of(item: TreeItem, parent: TreeItem) -> bool:
 	return false
 
 
+func _do_move_item(from: String, to: String, index: int) -> void:
+	var target: TreeItem = null
+	var new_parent: TreeItem = null
+	var current_folder: TreeItem = get_root()
+	
+	var to_slice: PackedStringArray = to.split("/", false)
+	var from_slice: PackedStringArray = from.split("/", false)
+	
+	if to_slice.is_empty() or from_slice.is_empty():
+		return
+	
+	var new_name: String = to_slice[-1]
+	
+	for slice in to_slice.slice(0, -1):
+		var found: bool = false
+		for item in current_folder.get_children():
+			if item.get_metadata(0)["name"] == slice:
+				if item.get_metadata(0)["type"] == ItemType.FOLDER:
+					current_folder = item
+					found = true
+				break
+		if not found:
+			return
+	
+	new_parent = current_folder
+	
+	if new_parent != get_root() and new_parent.get_metadata(0)["type"] != ItemType.FOLDER:
+		return
+	
+	for item in new_parent.get_children():
+		if item.get_metadata(0)["name"] == new_name:
+			return
+	
+	current_folder = get_root()
+	
+	for slice in from_slice:
+		var found: bool = false
+		for item in current_folder.get_children():
+			if item.get_metadata(0)["name"] == slice:
+				current_folder = item
+				found = true
+				break
+		if not found:
+			return
+	
+	target = current_folder
+	
+	target.set_text(0, new_name)
+	target.get_metadata(0)["name"] = new_name
+	
+	if target.get_parent() != new_parent:
+		target.get_parent().remove_child(target)
+		new_parent.add_child(target)
+		if -1 < index and target.get_index() != index:
+			if new_parent.get_child_count() <= 1:
+				return
+			if index == 0:
+				target.move_before(new_parent.get_first_child())
+			else:
+				target.move_after(new_parent.get_child(index - 1))
+
+
+func _is_in_tree(item: TreeItem) -> bool:
+	var current_level: TreeItem = item
+	var root: TreeItem = get_root()
+	
+	while current_level != null:
+		current_level = current_level.get_parent()
+		if current_level == get_root():
+			return true
+	return false
+
+
 func _drop_data(at_position: Vector2, data: Variant) -> void:
 	if not allow_drag_and_drop:
 		return
 	
-	var target: TreeItem = get_item_at_position(at_position)
 	var object: TreeItem = data["tree"]
+	var drop_target: TreeItem = get_item_at_position(at_position)
+	var new_parent: TreeItem = null
+	var from_this_tree: bool = _is_in_tree(object)
+	var original_index: int = object.get_index()
+	var original_path: String = _get_data_path(object)
+	var new_index: int = -1
 	
-	if target == null:
-		var root_count: int = get_root().get_child_count()
-		if object.get_parent() == get_root():
-			if 0 < root_count - 1 and object.get_index() < root_count - 1:
-				object.move_after(get_root().get_child(-1))
-		else:
-			if 0 < root_count:
-				object.move_after(get_root().get_child(-1))
-			else:
-				object.get_parent().remove_child(object)
-				get_root().add_child(object)
+	if drop_target == null:
+		new_parent = get_root()
+		new_index = -1
 	else:
+		var same_parent_shift: bool = from_this_tree and\
+				object.get_parent() == drop_target.get_parent() and\
+				object.get_index() < drop_target.get_index()
 		var drop_position: int = get_drop_section_at_position(at_position)
-		
 		match drop_position:
 			-1: # Above
-				object.move_before(target)
+				new_parent = drop_target.get_parent()
+				new_index = drop_target.get_index()
+				if same_parent_shift:
+					new_index -= 1
 			0: # On
-				object.get_parent().remove_child(object)
-				target.add_child(object)
+				new_index = -1
+				new_parent = drop_target
 			1: # Below
-				object.move_after(target)
-	data_changed.emit()
+				if drop_target.get_metadata(0)["type"] == ItemType.FOLDER and not drop_target.collapsed and 0 < drop_target.get_child_count():
+					new_index = 0
+					new_parent = drop_target
+				else:
+					new_parent = drop_target.get_parent()
+					new_index = drop_target.get_index()
+					if not same_parent_shift:
+						new_index += 1
+	
+	var drop_id: String = object.get_metadata(0)["name"]
+	if _tree_has_id(new_parent, drop_id):
+		drop_id = get_unique_id(new_parent, drop_id, object)
+	var drop_path: String = _get_data_path(new_parent).path_join(drop_id)
+	
+	if from_this_tree: # Data moved
+		if object.get_parent() != new_parent:
+			object.get_parent().remove_child(object)
+			new_parent.add_child(object)
+		if drop_id != object.get_metadata(0)["name"]:
+			object.set_text(0, drop_id)
+			object.get_metadata(0)["name"] = drop_id
+		
+		if new_parent.get_child(new_index) != object:
+			if new_index <= -1:
+				object.move_after(new_parent.get_child(-1))
+			elif new_index == 0:
+				object.move_before(new_parent.get_first_child())
+			else:
+				object.move_after(new_parent.get_child(new_index - 1))
+		
+		data_moved.emit(original_path, original_index, drop_path, new_index)
+	else: # Data created
+		data_created.emit(
+				drop_path,
+				new_index,
+				get_data_cell_data(object))
 
 
 func clear_data() -> void:
@@ -229,51 +341,289 @@ func clear_data() -> void:
 	create_item()
 
 
-func add_data(data_id: String, data: Variant, on_node: TreeItem = get_root(), id_editable: bool = true, value_editable: bool = true, can_delete: bool = true) -> void:
+func _get_data_path(item: TreeItem) -> String:
+	if item == null or item == get_root():
+		return ""
+	
+	var path: String = ""
+	
+	var items: Array[String] = []
+	
+	var current_item: TreeItem = item
+	var root: TreeItem = get_root()
+	
+	while current_item != root and current_item != null:
+		items.append(current_item.get_text(0))
+		current_item = current_item.get_parent()
+	
+	items.reverse()
+	
+	return StringUtils.make_path(items)
+
+
+func _get_data_item(path: String) -> TreeItem:
+	var parts: PackedStringArray = path.split("/", false)
+	if parts.is_empty():
+		return get_root()
+	
+	var current_item: TreeItem = get_root()
+	
+	for slice in parts:
+		var found: bool = false
+		for item in current_item.get_children():
+			if item.get_metadata(0)["name"] == slice:
+				found = true
+				current_item = item
+				break
+		if not found:
+			return null
+	
+	return current_item
+
+
+func _do_add_data(data_path: String, data: Variant, index: int = -1) -> void:
+	var parts: PackedStringArray = data_path.split("/", false)
+	if parts.is_empty():
+		return
+	var data_id: String = parts[-1]
+	if data_id.is_empty():
+		return
+	
+	var current_item: TreeItem = get_root()
+	for slice in parts.slice(0, -1):
+		var found: bool = false
+		for item in current_item.get_children():
+			if item.get_metadata(0)["name"] == slice:
+				current_item = item
+				found = true
+				break
+		if not found:
+			return
+	
+	if current_item == get_root() or current_item.get_metadata(0)["type"] == ItemType.FOLDER:
+		var can_add: bool = true
+		for item in current_item.get_children():
+			if item.get_metadata(0)["name"] == data_id:
+				can_add = false
+				break
+		if can_add:
+			_add_data_to_tree(data_id, data, current_item)
+
+
+func _do_erase_data(data_path: String) -> void:
+	var target: TreeItem = _get_data_item(data_path)
+	
+	if target == null or target == get_root():
+		return
+	
+	target.free()
+
+
+func _undo_erase_data(data_path: String, data: Variant, index: int) -> void:
+	var parts: PackedStringArray = data_path.rsplit("/", false)
+	if parts.is_empty():
+		NFPluginGameHandler._log_msg(
+				"editor - data tree",
+				"Failed to undo data erasure on empty path.",
+				NFPluginGameHandler._LogLevel.WARNING)
+		return
+	
+	var var_id: String = parts[-1]
+	var target: TreeItem = get_root()
+	
+	for path_slice in parts.slice(0, -1):
+		for item in target.get_children():
+			if item.get_metadata(0)["name"] == path_slice:
+				if item.get_metadata(0)["type"] != ItemType.FOLDER:
+					return
+				target = item
+				break
+	
+	for item in target.get_children():
+		if item.get_metadata(0)["name"] == var_id:
+			NFPluginGameHandler._log_msg(
+				"editor - data tree",
+				"Failed to undo data erasure. ID '%s' already used on path '%s'." % [var_id, _get_data_path(item.get_parent())],
+				NFPluginGameHandler._LogLevel.WARNING)
+			return
+	
+	
 	var data_type: int = typeof(data)
+	if data_type == TYPE_DICTIONARY or data_type == TYPE_ARRAY:
+		_add_data_to_tree(var_id, data.duplicate(true), target, index)
+	else:
+		_add_data_to_tree(var_id, data, target, index)
+
+
+func _undo_add_data(data_path: String) -> void:
+	var target: TreeItem = _get_data_item(data_path)
+	
+	if target != null and target != get_root():
+		target.free()
+
+
+func _do_rename_item(path: String, new_name: String) -> void:
+	var item: TreeItem = _get_data_item(path)
+	if item != null and item != get_root():
+		item.set_text(0, new_name)
+		item.get_metadata(0)["name"] = new_name
+
+
+func _data_type_to_internal(type: int) -> int:
+	match type:
+		TYPE_INT, TYPE_FLOAT, TYPE_BOOL, TYPE_STRING:
+			return type
+		_:
+			return TYPE_NIL
+
+
+func _do_update_item_data(path: String, data: Variant) -> void:
+	var item: TreeItem = _get_data_item(path)
+	
+	if item == null or item == get_root() or item.get_metadata(0)["type"] == ItemType.FOLDER:
+		return
+	
+	var new_type: int = _data_type_to_internal(typeof(data))
+	
+	if new_type != item.get_metadata(1):
+		if item.get_metadata(1) == TYPE_DICTIONARY:
+			var btn_idx: int = item.get_button_by_id(1, ButtonIds.TYPE_MENU)
+			if btn_idx != -1:
+				item.erase_button(1, btn_idx)
+		match new_type:
+			TYPE_INT:
+				item.set_icon(0, ICON_INT)
+				item.set_metadata(1, TYPE_INT)
+				item.set_cell_mode(1, TreeItem.CELL_MODE_RANGE)
+				item.set_range_config(1, RANGE_FLOOR, RANGE_CEIL, 1.0)
+				item.set_range(1, data)
+				item.set_editable(1, true)
+			TYPE_FLOAT:
+				item.set_icon(0, ICON_FLOAT)
+				item.set_metadata(1, TYPE_FLOAT)
+				item.set_cell_mode(1, TreeItem.CELL_MODE_RANGE)
+				item.set_range_config(1, RANGE_FLOOR, RANGE_CEIL, RANGE_FLOAT_STEP)
+				item.set_range(1, data)
+				item.set_editable(1, true)
+			TYPE_BOOL:
+				item.set_icon(0, ICON_BOOL)
+				item.set_metadata(1, TYPE_BOOL)
+				item.set_cell_mode(1, TreeItem.CELL_MODE_CHECK)
+				item.set_text(1, "Enabled")
+				item.set_checked(1, data)
+				item.set_editable(1, true)
+			TYPE_STRING:
+				item.set_icon(0, ICON_STRING)
+				item.set_metadata(1, TYPE_STRING)
+				item.set_cell_mode(1, TreeItem.CELL_MODE_STRING)
+				item.set_text(1, data)
+				item.set_editable(1, true)
+			TYPE_DICTIONARY:
+				item.set_icon(0, ICON_FOLDER)
+				item.set_metadata(1, TYPE_DICTIONARY)
+				item.set_selectable(1, false)
+				item.set_editable(0, true)
+				item.set_editable(1, false)
+				item.get_metadata(0)["type"] = ItemType.FOLDER
+				if compact_mode:
+					item.add_button(
+							1,
+							preload("res://addons/nexus_forge/icons/add_variable_icon.svg"),
+							ButtonIds.TYPE_MENU,
+							false,
+							"Add data")
+				else:
+					item.add_button(1, preload("res://addons/nexus_forge/icons/add_int.svg"), ButtonIds.INT, false, "Add Integer")
+					item.add_button(1, preload("res://addons/nexus_forge/icons/add_float.svg"), ButtonIds.FLOAT, false, "Add Float")
+					item.add_button(1, preload("res://addons/nexus_forge/icons/add_bool.svg"), ButtonIds.BOOL, false, "Add Bool")
+					item.add_button(1, preload("res://addons/nexus_forge/icons/add_string.svg"), ButtonIds.STRING, false, "Add String")
+					item.add_button(1, get_theme_icon("FolderCreate", "EditorIcons"), ButtonIds.LEVEL, false, "Add Level")
+				for subdata in data:
+					add_data(subdata, data[subdata], false, item)
+			_:
+				item.set_icon(0, ICON_VARIABLE)
+				item.set_metadata(1, TYPE_NIL)
+				item.get_metadata(0)["data"] = data
+				item.set_cell_mode(1, TreeItem.CELL_MODE_STRING)
+				item.set_text(1, type_string(typeof(data)))
+				item.set_editable(1, false)
+	else:
+		match new_type:
+			TYPE_INT, TYPE_FLOAT:
+				item.set_range(1, data)
+			TYPE_BOOL:
+				item.set_checked(1, data)
+			TYPE_STRING:
+				item.set_text(1, data)
+			_:
+				item.get_metadata(0)["data"] = data
+	
+	item.get_metadata(0)["value"] = data
+
+
+func add_data(data_id: String, data: Variant, initial_load: bool = false, on_node: TreeItem = get_root()) -> String:
 	var new_name: String = get_unique_id(on_node, data_id)
-	var new_data: TreeItem = on_node.create_child()
-	var metadata: Dictionary = {"name": new_name, "type": ItemType.DATA}
+	var data_path: String = _get_data_path(on_node).path_join(new_name)
+	
+	if initial_load:
+		_add_data_to_tree(
+				new_name,
+				data,
+				on_node)
+		return data_path
+	
+	var type: int = typeof(data)
+	
+	_add_data_to_tree(new_name, data, on_node)
+	
+	return data_path
+
+
+func _add_data_to_tree(new_name: String, data: Variant, on_node: TreeItem = get_root(), index: int = -1) -> TreeItem:
+	var data_type: int = typeof(data)
+	var new_data: TreeItem = on_node.create_child(index)
+	var metadata: Dictionary = {"name": new_name, "type": ItemType.DATA, "value": data}
 	
 	new_data.set_cell_mode(0, TreeItem.CELL_MODE_STRING)
 	new_data.set_text(0, new_name)
-	new_data.set_editable(0, id_editable)
+	new_data.set_editable(0, true)
 	
 	match data_type:
 		TYPE_INT:
 			new_data.set_icon(0, ICON_INT)
 			new_data.set_metadata(1, TYPE_INT)
 			new_data.set_cell_mode(1, TreeItem.CELL_MODE_RANGE)
-			new_data.set_range_config(1, -RANGE_MAX, RANGE_MAX, 1.0)
+			new_data.set_range_config(1, RANGE_FLOOR, RANGE_CEIL, 1.0)
 			new_data.set_range(1, data)
-			new_data.set_editable(1, value_editable)
+			new_data.set_editable(1, true)
 		TYPE_FLOAT:
 			new_data.set_icon(0, ICON_FLOAT)
 			new_data.set_metadata(1, TYPE_FLOAT)
 			new_data.set_cell_mode(1, TreeItem.CELL_MODE_RANGE)
-			new_data.set_range_config(1, -RANGE_MAX, RANGE_MAX, RANGE_FLOAT_STEP)
+			new_data.set_range_config(1, RANGE_FLOOR, RANGE_CEIL, RANGE_FLOAT_STEP)
 			new_data.set_range(1, data)
-			new_data.set_editable(1, value_editable)
+			new_data.set_editable(1, true)
 		TYPE_BOOL:
 			new_data.set_icon(0, ICON_BOOL)
 			new_data.set_metadata(1, TYPE_BOOL)
 			new_data.set_cell_mode(1, TreeItem.CELL_MODE_CHECK)
 			new_data.set_text(1, "Enabled")
 			new_data.set_checked(1, data)
-			new_data.set_editable(1, value_editable)
+			new_data.set_editable(1, true)
 		TYPE_STRING:
 			new_data.set_icon(0, ICON_STRING)
 			new_data.set_metadata(1, TYPE_STRING)
 			new_data.set_cell_mode(1, TreeItem.CELL_MODE_STRING)
 			new_data.set_text(1, data)
-			new_data.set_editable(1, value_editable)
+			new_data.set_editable(1, true)
 		TYPE_DICTIONARY:
 			new_data.set_icon(0, ICON_FOLDER)
 			new_data.set_metadata(1, TYPE_DICTIONARY)
 			new_data.set_selectable(1, false)
-			new_data.set_editable(0, id_editable)
+			new_data.set_editable(0, true)
 			new_data.set_editable(1, false)
 			metadata["type"] = ItemType.FOLDER
+			new_data.set_metadata(0, metadata)
 			if compact_mode:
 				new_data.add_button(
 						1,
@@ -288,7 +638,7 @@ func add_data(data_id: String, data: Variant, on_node: TreeItem = get_root(), id
 				new_data.add_button(1, preload("res://addons/nexus_forge/icons/add_string.svg"), ButtonIds.STRING, false, "Add String")
 				new_data.add_button(1, get_theme_icon("FolderCreate", "EditorIcons"), ButtonIds.LEVEL, false, "Add Level")
 			for subdata in data:
-				add_data(subdata, data[subdata], new_data)
+				_add_data_to_tree(subdata, data[subdata], new_data)
 		_:
 			new_data.set_icon(0, ICON_VARIABLE)
 			new_data.set_metadata(1, TYPE_NIL)
@@ -297,10 +647,19 @@ func add_data(data_id: String, data: Variant, on_node: TreeItem = get_root(), id
 			new_data.set_text(1, type_string(data_type))
 			new_data.set_editable(1, false)
 	
-	if can_delete:
-		new_data.add_button(1, TRASH_BIN, ButtonIds.DELETE, false, "Delete Data")
+	new_data.add_button(1, TRASH_BIN, ButtonIds.DELETE, false, "Delete Data")
+	if data_type != TYPE_DICTIONARY:
+		new_data.set_metadata(0, metadata)
 	
-	new_data.set_metadata(0, metadata)
+	return new_data
+
+
+func add_constant_data(new_name: String, data: Variant, on_node: TreeItem = get_root(), index: int = -1) -> void:
+	var valid_name: String = get_unique_id(on_node, new_name)
+	var data_tree: TreeItem = _add_data_to_tree(new_name, data, on_node, index)
+	data_tree.erase_button(
+			1,
+			data_tree.get_button_by_id(1, ButtonIds.DELETE))
 
 
 func get_data_cell_data(cell: TreeItem) -> Variant:
@@ -319,49 +678,111 @@ func get_data_cell_data(cell: TreeItem) -> Variant:
 				subfolder[sub_data.get_text(0)] = get_data_cell_data(sub_data)
 			return subfolder
 		TYPE_NIL:
-			return cell.get_metadata(0)["data"]
+			var type: int = typeof(cell.get_metadata(0)["data"])
+			if type == TYPE_DICTIONARY or type == TYPE_ARRAY:
+				return cell.get_metadata(0)["data"].duplicate(true)
+			else:
+				return cell.get_metadata(0)["data"]
 		_:
 			return null
 
 
 func _on_button_clicked(item: TreeItem, column: int, id: int, mouse_button_index: int) -> void:
+	var data_path: String = ""
+	var data_copy: Variant = null
 	match id:
 		ButtonIds.DELETE:
+			var path: String = _get_data_path(item)
+			var data: Variant = get_data_cell_data(item)
+			var index: int = item.get_index()
+			
 			item.free()
-			item_deleted.emit()
+			data_erased.emit(path, index, data)
+			return
 		ButtonIds.INT:
-			add_data("new_int", 0, item)
+			data_copy = 0
+			data_path = add_data("new_int", 0, false, item)
 		ButtonIds.FLOAT:
-			add_data("new_float", 0.0, item)
+			data_copy = 0.0
+			data_path = add_data("new_float", 0.0, false, item)
 		ButtonIds.BOOL:
-			add_data("new_bool", false, item)
+			data_copy = false
+			data_path = add_data("new_bool", false, false, item)
 		ButtonIds.STRING:
-			add_data("new_string", "", item)
+			data_copy = ""
+			data_path = add_data("new_string", "", false, item)
 		ButtonIds.LEVEL:
-			add_data("new_folder", {}, item)
+			data_copy = {}
+			data_path = add_data("new_folder", {}, false, item)
 		ButtonIds.TYPE_MENU:
 			data_item = item
 			mn.position = DisplayServer.mouse_get_position()
 			mn.popup()
 			return
-	data_changed.emit()
+	data_created.emit(
+			data_path,
+			-1,
+			data_copy)
 
 
 func on_data_edited() -> void:
-	if get_edited_column() != 0:
-		data_changed.emit()
+	var edited: TreeItem = get_edited()
+	var path: String = _get_data_path(edited)
+	
+	if get_edited_column() == 1: # Value
+		var from = edited.get_metadata(0)["value"]
+		var to = get_data_cell_data(edited)
+		var emit_update: bool = true
+		
+		match edited.get_metadata(1):
+			TYPE_INT, TYPE_FLOAT:
+				if edited.get_metadata(0)["value"] != int(edited.get_range(1)) if edited.get_metadata(1) == TYPE_INT else edited.get_range(1):
+					edited.get_metadata(0)["value"] = to
+				else:
+					emit_update = false
+			TYPE_BOOL:
+				if edited.get_metadata(0)["value"] != to:
+					edited.get_metadata(0)["value"] = to
+				else:
+					emit_update = false
+			TYPE_STRING:
+				if edited.get_metadata(0)["value"] != to:
+					edited.get_metadata(0)["value"] = to
+				else:
+					emit_update = false
+			TYPE_NIL:
+				if typeof(edited.get_metadata(0)["data"]) == typeof(edited.get_metadata(0)["value"]):
+					if edited.get_metadata(0)["data"] == edited.get_metadata(0)["value"]:
+						emit_update = false
+					else:
+						edited.get_metadata(0)["value"] = to
+		
+		if emit_update:
+			data_updated.emit(
+					path,
+					from,
+					to)
 		return
 	
-	var edited: TreeItem = get_edited()
+	# --- ID updated ---
 	
 	if edited.get_metadata(0)["name"] == edited.get_text(0):
 		return
 	
+	var old_name: String = edited.get_metadata(0)["name"]
 	var new_name: String = get_unique_id(edited.get_parent(), edited.get_text(0), edited)
+	
+	var parent_path: String = _get_data_path(edited.get_parent())
+	var old_path: String = parent_path.path_join(old_name)
+	var new_path: String = parent_path.path_join(new_name)
 	
 	edited.set_text(0, new_name)
 	edited.get_metadata(0)["name"] = new_name
-	data_changed.emit()
+	
+	data_renamed.emit(
+			parent_path,
+			old_name,
+			new_name)
 
 
 func get_data() -> Dictionary[String, Variant]:
@@ -380,6 +801,13 @@ func search_data(data_text: String) -> void:
 	for data in get_root().get_children():
 		data.visible = _child_has_data(data, data_text) or is_empty or data.get_text(0).containsn(data_text) or _data_cell_to_string(data).containsn(data_text)
 	current_search = data_text
+
+
+func _tree_has_id(item: TreeItem, id: String) -> bool:
+	for tree in item.get_children():
+		if tree.get_metadata(0)["name"] == id:
+			return true
+	return false
 
 
 func _child_has_data(item: TreeItem, text: String) -> bool:
@@ -402,4 +830,3 @@ func _data_cell_to_string(item: TreeItem) -> String:
 			return "true" if item.is_checked(1) else "false"
 		_:
 			return ""
-	

--- a/addons/nexus_forge/quests/events_tree.gd
+++ b/addons/nexus_forge/quests/events_tree.gd
@@ -673,7 +673,7 @@ func get_data_cell_data(cell: TreeItem) -> Variant:
 		TYPE_STRING:
 			return cell.get_text(1)
 		TYPE_DICTIONARY:
-			var subfolder: Dictionary = {}
+			var subfolder: Dictionary[String, Variant] = {}
 			for sub_data in cell.get_children():
 				subfolder[sub_data.get_text(0)] = get_data_cell_data(sub_data)
 			return subfolder
@@ -785,8 +785,8 @@ func on_data_edited() -> void:
 			new_name)
 
 
-func get_data() -> Dictionary[String, Variant]:
-	var rank_data: Dictionary[String, Variant] = {}
+func get_data() -> Dictionary[StringName, Variant]:
+	var rank_data: Dictionary[StringName, Variant] = {}
 	
 	for data_item in get_root().get_children():
 		rank_data[data_item.get_text(0)] = get_data_cell_data(data_item)

--- a/addons/nexus_forge/quests/events_tree.gd
+++ b/addons/nexus_forge/quests/events_tree.gd
@@ -792,8 +792,13 @@ func search_data(data_text: String) -> void:
 	if current_search == data_text:
 		return
 	var is_empty: bool = data_text.is_empty()
-	for data in get_root().get_children():
-		data.visible = _child_has_data(data, data_text) or is_empty or data.get_text(0).containsn(data_text) or _data_cell_to_string(data).containsn(data_text)
+	for folder in get_root().get_children():
+		var data_visible: bool = _child_has_data(folder, data_text) or\
+				is_empty or\
+				folder.get_text(0).containsn(data_text) or\
+				_data_cell_to_string(folder).containsn(data_text)
+		folder.visible = data_visible
+		
 	current_search = data_text
 
 
@@ -819,7 +824,7 @@ func _data_cell_to_string(item: TreeItem) -> String:
 		TreeItem.CELL_MODE_STRING:
 			return item.get_text(1)
 		TreeItem.CELL_MODE_RANGE:
-			return str(item.get_range(1))
+			return str(int(item.get_range(1)) if item.get_metadata(1) == TYPE_INT else item.get_range(1))
 		TreeItem.CELL_MODE_CHECK:
 			return "true" if item.is_checked(1) else "false"
 		_:

--- a/addons/nexus_forge/quests/new_odyssey_script.gd
+++ b/addons/nexus_forge/quests/new_odyssey_script.gd
@@ -2256,6 +2256,8 @@ func _notification(what: int) -> void:
 	if what == NOTIFICATION_PREDELETE:
 		for open_file in _open_files:
 			if is_instance_valid(_open_files[open_file]["quest_undo"]):
+				_open_files[open_file]["quest_undo"].clear_history()
 				_open_files[open_file]["quest_undo"].free()
 			if is_instance_valid(_open_files[open_file]["data_undo"]):
+				_open_files[open_file]["data_undo"].clear_history()
 				_open_files[open_file]["data_undo"].free()

--- a/addons/nexus_forge/quests/new_odyssey_script.gd
+++ b/addons/nexus_forge/quests/new_odyssey_script.gd
@@ -2,19 +2,20 @@
 extends PanelContainer
 
 
-
 enum QuestModeType {
 	NONE = 0,
 	QUEST = 1,
 	STAGE = 2,
 	OBJECTIVE = 3}
 
+const MAX_UNDO_STEPS: int = 50
+
 var quest_mode: QuestModeType = QuestModeType.NONE
 var quest_resource: Quest = null
+var undo: UndoRedo = null
 
 var selected_stage: StringName = &""
 var selected_objective: StringName = &""
-var _logic_offset: int = 225
 
 var _open_files: Dictionary[int, Dictionary] = {}
 
@@ -88,6 +89,10 @@ func ready_plugin() -> void:
 	events_tree.ready_plugin()
 	custom_data_tree.ready_plugin()
 	
+	if custom_data_tree.has_undo():
+		custom_data_tree._undo.free()
+		custom_data_tree._undo = null
+	
 	add_req_dict_button.icon = get_theme_icon("FolderCreate", "EditorIcons")
 	add_dict_button.icon = get_theme_icon("FolderCreate", "EditorIcons")
 	file_search_ln_edt.right_icon = get_theme_icon("Search", "EditorIcons")
@@ -111,7 +116,7 @@ func ready_plugin() -> void:
 	
 	quest_search_ln_edit.text_changed.connect(_on_search_quest_text_changed)
 	
-	quest_tree.quest_selected.connect(_on_quest_selected)
+	quest_tree.quest_selected.connect(_on_quest_root_selected)
 	quest_tree.stage_selected.connect(_on_stage_selected)
 	quest_tree.objective_selected.connect(_on_objective_selected)
 	quest_tree.stage_created.connect(_on_stage_created)
@@ -302,6 +307,18 @@ func set_ui_enabled(enabled: bool) -> void:
 	add_dict_button.disabled = disabled
 
 
+func update_crumbs_label() -> void:
+	if quest_resource == null:
+		crumbs_label.text = ""
+		return
+	var items: Array[String] = [String(quest_resource.id)]
+	if not selected_stage.is_empty():
+		items.append(String(selected_stage))
+	if not selected_objective.is_empty():
+		items.append(String(selected_objective))
+	crumbs_label.text = " / ".join(items)
+
+
 func set_stage_target_disabled(target: StringName) -> void:
 	for idx in range(1, success_pointer_opt_btn.item_count):
 		var disabled: bool = success_pointer_opt_btn.get_item_metadata(idx) == target
@@ -364,40 +381,42 @@ func select_failure_pointer(target: StringName) -> void:
 			return
 
 
-func save_current_data() -> void:
+func save_current_quest() -> void:
+	if quest_resource == null:
+		return
+	
+	_open_files[quest_resource.get_instance_id()] = quest_tree.get_quest_structure()
+	
 	if quest_mode == QuestModeType.QUEST:
 		quest_resource.type = type_opt_btn.get_selected_metadata() if -1 < type_opt_btn.selected else 0
 		quest_resource.title = title_ln_edt.text.strip_edges()
 		quest_resource.description = description_txt_edt.text.strip_edges()
-		quest_resource.custom_data.clear()
-		quest_resource.custom_data.assign(custom_data_tree.get_data())
+		quest_resource.custom_data = custom_data_tree.get_data()
 		
 		quest_resource.on_success_events.clear()
 		quest_resource.on_failure_events.clear()
 		
 		var events_data: Dictionary = events_tree.get_data()
-		quest_resource.on_success_events.assign(events_data["Success Events"])
-		quest_resource.on_failure_events.assign(events_data["Failure Events"])
+		quest_resource.events[&"success"] = events_data["Success Events"]
+		quest_resource.events[&"failure"] = events_data["Failure Events"]
+	
 	elif quest_mode == QuestModeType.STAGE:
 		if not quest_resource.has_stage(selected_stage):
 			return
+		
 		var stage: QuestStage = quest_resource.get_stage(selected_stage)
 		
 		stage.type = type_opt_btn.get_selected_metadata() if -1 < type_opt_btn.selected else 0
 		stage.title = title_ln_edt.text.strip_edges()
 		stage.description = description_txt_edt.text.strip_edges()
-		stage.custom_data.clear()
-		stage.custom_data.assign(custom_data_tree.get_data())
+		stage.custom_data = custom_data_tree.get_data()
 		
 		stage.success_stage_id = success_pointer_opt_btn.get_selected_metadata()
 		stage.failure_stage_id = failure_pointer_opt_btn.get_selected_metadata()
 		
-		stage.on_success_events.clear()
-		stage.on_failure_events.clear()
-		
 		var events_data: Dictionary = events_tree.get_data()
-		stage.on_success_events.assign(events_data["Success Events"])
-		stage.on_failure_events.assign(events_data["Failure Events"])
+		stage.events[&"success"] = events_data["Success Events"]
+		stage.events[&"failure"] = events_data["Failure Events"]
 	
 	elif quest_mode == QuestModeType.OBJECTIVE:
 		if not quest_resource.has_stage(selected_stage) or not quest_resource.get_stage(selected_stage).has_objective(selected_objective):
@@ -410,13 +429,11 @@ func save_current_data() -> void:
 		objective.custom_data.clear()
 		objective.custom_data.assign(custom_data_tree.get_data())
 		
-		objective.on_success_events.clear()
-		objective.on_failure_events.clear()
 		objective.clear_requirements()
 		
 		var events_data: Dictionary = events_tree.get_data()
-		objective.on_success_events.assign(events_data["Success Events"])
-		objective.on_failure_events.assign(events_data["Failure Events"])
+		objective.events[&"success"] = events_data["Success Events"]
+		objective.events[&"failure"] = events_data["Failure Events"]
 		
 		quest_resource.get_stage(selected_stage).set_objective_required(
 				selected_objective,
@@ -427,33 +444,32 @@ func save_current_data() -> void:
 
 func plugin_handle_resource(quest: Quest) -> void:
 	if quest_resource != null and quest != quest_resource:
-		save_current_data()
+		save_current_quest()
 		files_tree.set_quest_structure(quest_resource, quest_tree.get_quest_structure())
 	
-	if files_tree.has_quest(quest):
-		files_tree.select_quest(quest)
+	var id: int = quest.get_instance_id()
+	
+	if _open_files.has(id):
+		files_tree.select_quest(id, false)
 	else:
-		var cfg: ConfigFile = ConfigFile.new()
-		var filepath: String = quest.resource_path
-		var filename: String = filepath.get_file()
-		var path_hash: String = filepath.md5_text()
-		var absolute_path: String ="res://.godot/editor/"
-		var cfg_filename: String = str(filename, "-treestate-", path_hash, ".cfg")
-		var end_path: String = absolute_path.path_join(cfg_filename)
-		if FileAccess.file_exists(end_path):
-			cfg.load(end_path)
-		var structure: Array[Dictionary] = cfg.get_value("Layout", "quest_structure", ArrayUtils.create_typed(TYPE_DICTIONARY))
-		
-		var pointers: Array[StringName] = []
-		pointers.assign(quest.stages())
-		pointers.sort_custom(ArrayUtils.sort_custom_alphabetically_asc)
-		set_stage_target_pointers(pointers)
-		files_tree.add_quest(quest, true, false)
-		quest_tree.set_quest(quest)
-		quest_tree.set_quest_structure(structure)
-		quest_resource = quest
-		set_quest_mode(QuestModeType.QUEST)
-		load_quest()
+		add_quest_resource(quest)
+
+
+func display_quest(quest_id: int) -> void:
+	if not _open_files.has(quest_id):
+		return
+	
+	var quest: Quest = _open_files[quest_id]["resource"]
+	
+	var pointers: Array[StringName] = []
+	pointers.assign(quest.stages())
+	pointers.sort_custom(ArrayUtils.sort_custom_alphabetically_asc)
+	set_stage_target_pointers(pointers)
+	quest_tree.set_quest(quest)
+	quest_tree.set_quest_structure(_open_files[quest_id]["structure"])
+	quest_resource = quest
+	set_quest_mode(QuestModeType.QUEST)
+	load_quest_data()
 
 
 func select_type(type: int) -> void:
@@ -463,47 +479,57 @@ func select_type(type: int) -> void:
 			return
 
 
-func load_quest() -> void:
+func load_quest_data() -> void:
 	quest_mode = QuestModeType.QUEST
 	set_quest_mode(QuestModeType.QUEST)
 	
 	selected_stage = &""
 	selected_objective = &""
 	
-	crumbs_label.text = String(quest_resource.id)
+	update_crumbs_label()
 	
 	title_ln_edt.text = quest_resource.title
+	title_ln_edt.set_meta(&"old_value", quest_resource.title)
 	select_type(quest_resource.type)
 	description_txt_edt.text = quest_resource.description
+	description_txt_edt.set_meta(&"old_value", quest_resource.description)
 	
 	events_tree.clear_data()
-	custom_data_tree.clear_data()
+	custom_data_tree.clear_data(false)
 	
 	for data_key in quest_resource.custom_data.keys():
-		custom_data_tree.add_data(data_key, quest_resource.custom_data[data_key])
+		custom_data_tree.add_data(
+				data_key,
+				quest_resource.custom_data[data_key],
+				true)
 	
 	events_tree.add_data("Success Events", quest_resource.on_success_events, events_tree.get_root(), false, false, false)
 	events_tree.add_data("Failure Events", quest_resource.on_failure_events, events_tree.get_root(), false, false, false)
 
 
-func load_stage(stage_id: StringName) -> void:
+func load_stage_data(stage_id: StringName) -> void:
 	var stage: QuestStage = quest_resource.get_stage(stage_id)
 	
 	quest_mode = QuestModeType.STAGE
 	set_quest_mode(QuestModeType.STAGE)
 	
 	title_ln_edt.text = stage.title
+	title_ln_edt.set_meta(&"old_value", stage.title)
 	description_txt_edt.text = stage.description
+	description_txt_edt.set_meta(&"old_value", stage.description)
 	select_type(stage.type)
 	
 	select_success_pointer(stage.success_stage_id)
 	select_failure_pointer(stage.failure_stage_id)
 	
 	events_tree.clear_data()
-	custom_data_tree.clear_data()
+	custom_data_tree.clear_data(false)
 	
 	for data_key in stage.custom_data.keys():
-		custom_data_tree.add_data(data_key, stage.custom_data[data_key])
+		custom_data_tree.add_data(
+				data_key,
+				stage.custom_data[data_key],
+				true)
 	
 	events_tree.add_data("Success Events", stage.on_success_events, events_tree.get_root(), false, false, false)
 	events_tree.add_data("Failure Events", stage.on_failure_events, events_tree.get_root(), false, false, false)
@@ -511,26 +537,31 @@ func load_stage(stage_id: StringName) -> void:
 	selected_stage = stage_id
 	selected_objective = &""
 	
-	crumbs_label.text = String(quest_resource.id) + " / " + String(stage_id)
+	update_crumbs_label()
 
 
-func load_objective(stage_id: StringName, objective_id: StringName) -> void:
+func load_objective_data(stage_id: StringName, objective_id: StringName) -> void:
 	var objective: QuestObjective = quest_resource.get_stage(stage_id).get_objective(objective_id)
 	
 	quest_mode = QuestModeType.OBJECTIVE
 	set_quest_mode(QuestModeType.OBJECTIVE)
 	
 	title_ln_edt.text = objective.title
+	title_ln_edt.set_meta(&"old_value", objective.title)
 	description_txt_edt.text = objective.description
+	description_txt_edt.set_meta(&"old_value", objective.description)
 	select_type(objective.type)
 	
 	events_tree.clear_data()
-	custom_data_tree.clear_data()
+	custom_data_tree.clear_data(false)
 	
 	obj_req_tree.set_data(objective._requirements)
 	
 	for data_key in objective.custom_data.keys():
-		custom_data_tree.add_data(data_key, objective.custom_data[data_key])
+		custom_data_tree.add_data(
+				data_key,
+				objective.custom_data[data_key],
+				true)
 	
 	obj_req_chk_bx.set_pressed_no_signal(quest_resource.get_stage(stage_id).is_objective_required(objective_id))
 	
@@ -540,7 +571,7 @@ func load_objective(stage_id: StringName, objective_id: StringName) -> void:
 	selected_stage = stage_id
 	selected_objective = objective_id
 	
-	crumbs_label.text = String(quest_resource.id) + " / " + String(stage_id) + " / " + String(objective_id)
+	update_crumbs_label()
 
 
 func has_unsaved_files() -> bool:
@@ -549,7 +580,7 @@ func has_unsaved_files() -> bool:
 
 func save_resource() -> void:
 	if quest_resource != null:
-		save_current_data()
+		save_current_quest()
 		files_tree.set_quest_structure(quest_resource, quest_tree.get_quest_structure())
 	
 	for quest_file:Dictionary in files_tree.get_unsaved_files():
@@ -579,23 +610,77 @@ func get_open_files() -> Array[String]:
 
 func open_files(paths: Array[String]) -> void:
 	for path in paths:
-		if not ResourceLoader.exists(path):
-			continue
-		var res: Resource = load(path)
-		if res is Quest:
-			var cfg: ConfigFile = ConfigFile.new()
-			var filepath: String = res.resource_path
-			var filename: String = filepath.get_file()
-			var path_hash: String = filepath.md5_text()
-			var absolute_path: String ="res://.godot/editor/"
-			var cfg_filename: String = str(filename, "-treestate-", path_hash, ".cfg")
-			var end_path: String = absolute_path.path_join(cfg_filename)
-			if FileAccess.file_exists(end_path):
-				cfg.load(end_path)
-			var structure: Array[Dictionary] = cfg.get_value("Layout", "quest_structure", ArrayUtils.create_typed(TYPE_DICTIONARY))
-			
-			files_tree.add_quest(res)
-			files_tree.set_quest_structure(res, structure)
+		open_quest_file(path)
+
+
+func open_quest_file(file_path: String) -> void:
+	if not ResourceLoader.exists(file_path):
+		return
+	
+	var res: Resource = load(file_path)
+	if res == null or res is not Quest:
+		return
+	
+	var res_id: int = res.get_instance_id()
+	
+	if files_tree.has_quest_file(res.resource_path) or _open_files.has(res_id):
+		return
+	
+	add_quest_resource(res)
+
+
+func add_quest_resource(quest: Quest) -> void:
+	var quest_undo: UndoRedo = UndoRedo.new()
+	var data_undo: UndoRedo = UndoRedo.new()
+	var structure: Array[Dictionary] = get_layout_config_for_file(quest.resource_path)
+	
+	_open_files[quest.get_instance_id()] = {
+		"resource": quest,
+		"quest_undo": quest_undo,
+		"data_undo": data_undo,
+		"structure": structure}
+	
+	files_tree.add_quest(
+			quest,
+			quest.resource_path)
+
+
+func get_layout_config_for_file(file_path: String) -> Array[Dictionary]:
+	var filename: String = file_path.get_file()
+	var path_hash: String = file_path.md5_text()
+	var absolute_path: String = "res://.godot/editor/"
+	var cfg_filename: String = str(filename, "-treestate-", path_hash, ".cfg")
+	var end_path: String = absolute_path.path_join(cfg_filename)
+	return _get_layout_config(end_path)
+
+
+func _get_layout_config(config_path: String) -> Array[Dictionary]:
+	var structure: Array[Dictionary] = []
+	
+	if not FileAccess.file_exists(config_path):
+		return structure
+	
+	var cfg: ConfigFile = ConfigFile.new()
+	
+	if not FileAccess.file_exists(config_path):
+		return structure
+		
+	if cfg.load(config_path) != OK:
+		return structure
+	
+	if not cfg.has_section_key("Layout", "quest_structure"):
+		return structure
+	
+	var value = cfg.get_value("Layout", "quest_structure")
+	
+	if typeof(value) != TYPE_ARRAY:
+		return structure
+	
+	for item in value:
+		if typeof(item) == TYPE_DICTIONARY:
+			structure.append(value)
+	
+	return structure
 
 
 func _add_quest_requirement_data_pressed(data: Variant) -> void:
@@ -606,19 +691,19 @@ func _on_something_changed(_arg = null) -> void:
 	files_tree.set_current_save_required(true)
 
 
-func _on_quest_selected(_quest_id: StringName) -> void:
+func _on_quest_root_selected() -> void:
 	if quest_resource == null:
 		return
-	save_current_data()
-	load_quest()
+	save_current_quest()
+	load_quest_data()
 
 
 func _on_stage_selected(stage_id: StringName) -> void:
 	if quest_resource == null or (selected_stage == stage_id and selected_objective == &""):
 		return
 	
-	save_current_data()
-	load_stage(stage_id)
+	save_current_quest()
+	load_stage_data(stage_id)
 	set_stage_target_disabled(String(stage_id))
 
 
@@ -626,9 +711,9 @@ func _on_objective_selected(stage_id: StringName, objective_id: StringName) -> v
 	if quest_resource == null or (selected_stage == stage_id and selected_objective == objective_id):
 		return
 	
-	save_current_data()
+	save_current_quest()
 	
-	load_objective(stage_id, objective_id)
+	load_objective_data(stage_id, objective_id)
 
 
 func _on_stage_created(stage_id: StringName) -> void:
@@ -653,7 +738,7 @@ func _on_objective_created(stage_id: StringName, objective_id: StringName) -> vo
 func _on_quest_id_changed(_from: StringName, to: StringName) -> void:
 	quest_resource.id = to
 	_on_something_changed()
-	crumbs_label.text = String(to)
+	update_crumbs_label()
 
 
 func _on_stage_id_changed(from: StringName, to: StringName) -> void:
@@ -666,7 +751,7 @@ func _on_stage_id_changed(from: StringName, to: StringName) -> void:
 	if selected_stage == from:
 		selected_stage = to
 	
-	crumbs_label.text = String(quest_resource.id) + " / " + String(to)
+	update_crumbs_label()
 	
 	_on_something_changed() 
 
@@ -683,26 +768,28 @@ func _on_objective_id_changed(on_stage: StringName, from: StringName, to: String
 	if selected_stage == on_stage and selected_objective == from:
 		selected_objective = to
 	
-	crumbs_label.text = String(quest_resource.id) + " / " + String(selected_stage) + " / " + String(to)
+	update_crumbs_label()
 	
 	_on_something_changed()
 
 
-func _on_quest_resource_selected(quest: Quest, structure: Array[Dictionary]) -> void:
+func _on_quest_resource_selected(quest_id: int) -> void:
 	if quest_resource != null:
-		save_current_data()
-		files_tree.set_quest_structure(quest_tree.get_quest_structure())
+		save_current_quest()
 	
-	quest_resource = quest
-	quest_tree.set_quest(quest, true, false)
-	quest_tree.set_quest_structure(structure)
+	var resource: Quest = _open_files[quest_id]["resource"]
+	quest_resource = resource
+	undo = _open_files[quest_id]["quest_undo"]
+	custom_data_tree.set_undo(_open_files[quest_id]["data_undo"])
+	quest_tree.set_quest(resource, true, false)
+	quest_tree.set_quest_structure(_open_files[quest_id]["structure"])
 	
-	var stages: Array[StringName] = quest.stages()
-	stages.sort_custom(func(a:StringName,b:StringName): return String(a) < String(b))
+	var stages: Array[StringName] = resource.stages()
+	stages.sort_custom(func(a:StringName,b:StringName): return a.naturalnocasecmp_to(String(b)) < 0)
 	
 	set_stage_target_pointers(stages)
 	
-	load_quest()
+	load_quest_data()
 
 
 func _on_objective_rearranged(from_stage: StringName, to_stage: StringName, objective_id: StringName) -> void:
@@ -723,35 +810,67 @@ func _on_new_quest_file_pressed() -> void:
 	dialog.popup()
 	
 	var result: Array = await dialog.dialog_finished
-	
-	if result[0]:
-		if quest_resource != null:
-			save_current_data()
-			files_tree.set_quest_structure(quest_resource, quest_tree.get_quest_structure())
-		
-		
-		
-		
-		if ResourceLoader.exists(result[1]):
-			files_tree.close_with_path(result[1])
-		var new_quest: Quest = Quest.new()
-		if new_quest.id.is_empty():
-			new_quest.id = &"new_quest"
-		ResourceSaver.save(new_quest, result[1])
-		if ResourceLoader.has_cached(result[1]):
-			new_quest.take_over_path(result[1])
-		else:
-			new_quest.resource_path = result[1]
-		
-		files_tree.add_quest(new_quest, true, false)
-		quest_resource = new_quest
-		quest_tree.set_quest(new_quest, true, false)
-		load_quest()
-		var pointers: Array[StringName] = []
-		pointers.assign(new_quest.stages())
-		pointers.sort_custom(ArrayUtils.sort_custom_alphabetically_asc)
-		set_stage_target_pointers(pointers)
 	dialog.queue_free()
+	
+	if not result[0]:
+		return
+	
+	if quest_resource != null:
+		save_current_quest()
+	
+	var new_quest: Quest = Quest.new()
+	var quest_undo: UndoRedo = UndoRedo.new()
+	var data_undo: UndoRedo = UndoRedo.new()
+	var quest_id: int = new_quest.get_instance_id()
+	var take_over: bool = false
+	
+	quest_undo.max_steps = MAX_UNDO_STEPS
+	data_undo.max_steps = MAX_UNDO_STEPS
+	
+	if new_quest.id.is_empty():
+		new_quest.id = &"new_quest"
+	
+	if ResourceLoader.has_cached(result[1]):
+		var cached_resource: Resource = ResourceLoader.get_cached_ref(result[1])
+		var old_id: int = cached_resource.get_instance_id()
+		take_over = true
+		if _open_files.has(old_id):
+			_open_files[old_id]["undo"].free()
+			_open_files.erase(old_id)
+			files_tree.remove_quest(old_id)
+	else:
+		new_quest.resource_path = result[1]
+	
+	ResourceSaver.save(new_quest, result[1])
+	if take_over:
+		new_quest.take_over_path(result[1])
+	
+	_open_files[quest_id] = {
+		"resource": new_quest,
+		"quest_undo": quest_undo,
+		"data_undo": data_undo,
+		"structure": ArrayUtils.create_typed(TYPE_DICTIONARY)}
+	
+	undo = quest_undo
+	custom_data_tree.set_undo(data_undo)
+	quest_resource = new_quest
+	
+	files_tree.add_quest(
+			quest_id,
+			result[1],
+			true, # Select
+			false) # Emit select
+	
+	quest_tree.set_quest(
+			new_quest,
+			true, # Select
+			false) # Emit Select
+	
+	load_quest_data() # Loads the quest data
+	var pointers: Array[StringName] = []
+	pointers.assign(new_quest.stages())
+	pointers.sort_custom(ArrayUtils.sort_custom_alphabetically_asc)
+	set_stage_target_pointers(pointers)
 
 
 func _on_search_files_text_changed(text: String) -> void:
@@ -777,7 +896,7 @@ func _on_search_requirement_text_changed(text: String) -> void:
 	obj_req_tree.search_data(clean_text)
 
 
-func _on_quest_close_pressed(quest: Quest, requires_save: bool, structure: Array[Dictionary]) -> void:
+func _on_quest_close_pressed(quest_id: int, requires_save: bool, structure: Array[Dictionary]) -> void:
 	if requires_save:
 		var confirm_dialog: AcceptDialog = load("res://addons/nexus_forge/dialogs/unsaved_dialog_script.gd").new()
 		confirm_dialog.dialog_text = "File has unsaved changes. Save before closing?"
@@ -789,36 +908,43 @@ func _on_quest_close_pressed(quest: Quest, requires_save: bool, structure: Array
 		var result: int = await confirm_dialog.dialog_finished
 		
 		if result == 0:
-			if quest == quest_resource:
-				save_current_data()
+			var quest_res: Quest = _open_files[quest_id]["resource"]
+			if quest_res == quest_resource:
+				save_current_quest()
 			
-			_save_cfg_for(quest.resource_path, structure)
+			_save_cfg_for(
+					quest_res.resource_path,
+					structure)
 			
-			
-			ResourceSaver.save(quest)
+			ResourceSaver.save(quest_res)
 		elif result == 2:
 			confirm_dialog.queue_free()
 			return
 	
-	files_tree.close_quest(quest)
-	
-	if quest == quest_resource:
-		crumbs_label.text = ""
+	if quest_resource.get_instance_id() == quest_id:
 		title_ln_edt.text = ""
 		description_txt_edt.text = ""
 		quest_resource = null
 		quest_mode = QuestModeType.NONE
 		set_quest_mode(QuestModeType.NONE)
-		custom_data_tree.clear_data()
 		events_tree.clear_data()
 		quest_tree.clear()
+		custom_data_tree.clear_data(false)
+		undo = null
+		custom_data_tree.set_undo(null)
+		update_crumbs_label()
+	
+	files_tree.remove_quest(quest_id)
+	_open_files[quest_id]["quest_undo"].free()
+	_open_files[quest_id]["data_undo"].free()
+	_open_files.erase(quest_id)
 
 
 func _on_stage_erased(stage_id: StringName) -> void:
 	quest_resource.remove_stage(stage_id)
 	if selected_stage == stage_id and selected_objective == &"":
 		quest_tree.select_quest()
-		load_quest()
+		load_quest_data()
 	_on_something_changed()
 
 
@@ -827,7 +953,7 @@ func _on_objective_erased(from_stage: StringName, objective_id: StringName) -> v
 	
 	if selected_stage == from_stage and selected_objective == objective_id:
 		quest_tree.select_stage(selected_stage, false)
-		load_stage(from_stage)
+		load_stage_data(from_stage)
 	
 	_on_something_changed()
 
@@ -972,3 +1098,12 @@ func _on_objective_duplicated(from_stage: StringName, objective_id: StringName, 
 
 func _on_quest_type_selected() -> void:
 	pass
+
+
+func _notification(what: int) -> void:
+	if what == NOTIFICATION_PREDELETE:
+		for open_file in _open_files:
+			if is_instance_valid(_open_files[open_file]["quest_undo"]):
+				_open_files[open_file]["quest_undo"].free()
+			if is_instance_valid(_open_files[open_file]["data_undo"]):
+				_open_files[open_file]["data_undo"].free()

--- a/addons/nexus_forge/quests/new_odyssey_script.gd
+++ b/addons/nexus_forge/quests/new_odyssey_script.gd
@@ -2058,7 +2058,7 @@ func _do_move_objective(objective_id: StringName, from_stage: StringName, to_sta
 			to_index)
 
 
-func _on_stage_erased(stage_id: StringName, index: int) -> void:
+func _on_stage_erased(stage_id: StringName, index: int, objective_order: Array[String]) -> void:
 	var original_stage: QuestStage = quest_resource.get_stage(stage_id)
 	var duplicate_stage: QuestStage = original_stage.duplicate(true)
 	# --- Godot 4.4 Compatibility code ---
@@ -2105,13 +2105,14 @@ func _on_stage_erased(stage_id: StringName, index: int) -> void:
 	undo.add_undo_method(_undo_erase_stage.bind(
 			duplicate_stage,
 			index,
-			targeted_stages))
+			targeted_stages,
+			objective_order))
 	undo.commit_action(false)
 	
 	_on_something_changed()
 
 
-func _undo_erase_stage(stage_res: QuestStage, index: int, pointers_patch: Dictionary[StringName, Dictionary]) -> void:
+func _undo_erase_stage(stage_res: QuestStage, index: int, pointers_patch: Dictionary[StringName, Dictionary], objectives: Array[String]) -> void:
 	if quest_resource.has_stage(stage_res.id):
 		NFPluginGameHandler._log_msg(
 				"odyssey - editor",
@@ -2126,6 +2127,8 @@ func _undo_erase_stage(stage_res: QuestStage, index: int, pointers_patch: Dictio
 	# Godot 4.5, but NexusForge 1.X will support 4.4. On version 2.0, supported
 	# versions will be changed just ahead enough to solve old issues like this.
 	for objective_id in stage_res.objectives():
+		if not objectives.has(String(objective_id)):
+			objectives.append(String(objective_id))
 		var saved_objective: QuestObjective = stage_res.get_objective(objective_id)
 		var restored_objective: QuestObjective = saved_objective.duplicate(true)
 		restored_stage._objectives[objective_id]["objective"] = restored_objective
@@ -2142,6 +2145,7 @@ func _undo_erase_stage(stage_res: QuestStage, index: int, pointers_patch: Dictio
 	
 	quest_resource.add_stage(stage_res)
 	quest_tree.add_stage(stage_res.id, index)
+	quest_tree._restore_objectives(stage_res.id, objectives)
 	
 	update_stage_target_pointers()
 

--- a/addons/nexus_forge/quests/new_odyssey_script.gd
+++ b/addons/nexus_forge/quests/new_odyssey_script.gd
@@ -1032,7 +1032,7 @@ func _on_search_requirement_text_changed(text: String) -> void:
 	obj_req_tree.search_data(clean_text)
 
 
-func _on_quest_close_pressed(quest_id: int, requires_save: bool, structure: Array[Dictionary]) -> void:
+func _on_quest_close_pressed(quest_id: int, requires_save: bool) -> void:
 	if requires_save:
 		var confirm_dialog: AcceptDialog = load("res://addons/nexus_forge/dialogs/unsaved_dialog_script.gd").new()
 		confirm_dialog.dialog_text = "File has unsaved changes. Save before closing?"
@@ -1050,7 +1050,7 @@ func _on_quest_close_pressed(quest_id: int, requires_save: bool, structure: Arra
 			
 			_save_cfg_for(
 					quest_res.resource_path,
-					structure)
+					_open_files[quest_id]["structure"])
 			
 			ResourceSaver.save(quest_res)
 		elif result == 2:

--- a/addons/nexus_forge/quests/new_odyssey_script.gd
+++ b/addons/nexus_forge/quests/new_odyssey_script.gd
@@ -16,6 +16,8 @@ var selected_stage: StringName = &""
 var selected_objective: StringName = &""
 var _logic_offset: int = 225
 
+var _open_files: Dictionary[int, Dictionary] = {}
+
 @onready var obj_req_chk_bx: CheckBox = $MainContainer/DataContainer/DataContainer/LogicContainer/TargetLogicContainer/ObjReqChkBx
 @onready var crumbs_label: Label = $MainContainer/TitleContainer/CrumbsContainer/CrumbsLabel
 @onready var file_search_ln_edt: LineEdit = $MainContainer/DataContainer/NavigationContainer/FileBarContainer/FileSearchLnEdt
@@ -726,6 +728,10 @@ func _on_new_quest_file_pressed() -> void:
 		if quest_resource != null:
 			save_current_data()
 			files_tree.set_quest_structure(quest_resource, quest_tree.get_quest_structure())
+		
+		
+		
+		
 		if ResourceLoader.exists(result[1]):
 			files_tree.close_with_path(result[1])
 		var new_quest: Quest = Quest.new()
@@ -960,3 +966,9 @@ func _on_objective_duplicated(from_stage: StringName, objective_id: StringName, 
 	
 	stage.add_objective(objective, stage.is_objective_required(objective_id))
 	_on_something_changed()
+
+
+# ------ UNDO/REDO ------
+
+func _on_quest_type_selected() -> void:
+	pass

--- a/addons/nexus_forge/quests/new_odyssey_script.gd
+++ b/addons/nexus_forge/quests/new_odyssey_script.gd
@@ -181,9 +181,9 @@ func ready_plugin() -> void:
 	add_req_string_button.pressed.connect(_add_quest_requirement_data_pressed.bind(""))
 	
 	# Unsaved triggers
-	obj_req_tree.data_changed.connect(_on_something_changed)
+	#obj_req_tree.data_changed.connect(_on_something_changed)
 	custom_data_tree.data_changed.connect(_on_something_changed)
-	events_tree.data_changed.connect(_on_something_changed)
+	#events_tree.data_changed.connect(_on_something_changed)
 	type_opt_btn.item_selected.connect(_on_something_changed)
 	title_ln_edt.text_changed.connect(_on_something_changed)
 	description_txt_edt.text_changed.connect(_on_something_changed)
@@ -478,7 +478,7 @@ func save_current_quest() -> void:
 	if quest_resource == null:
 		return
 	
-	_open_files[quest_resource.get_instance_id()] = quest_tree.get_quest_structure()
+	_open_files[quest_resource.get_instance_id()]["structure"] = quest_tree.get_quest_structure()
 	
 	if quest_mode == QuestModeType.QUEST:
 		quest_resource.type = type_opt_btn.get_selected_metadata() if -1 < type_opt_btn.selected else 0
@@ -486,8 +486,7 @@ func save_current_quest() -> void:
 		quest_resource.description = description_txt_edt.text.strip_edges()
 		quest_resource.custom_data = custom_data_tree.get_data()
 		
-		quest_resource.on_success_events.clear()
-		quest_resource.on_failure_events.clear()
+		quest_resource.events.clear()
 		
 		var events_data: Dictionary = events_tree.get_data()
 		quest_resource.events[&"success"] = events_data["Success Events"]
@@ -547,6 +546,7 @@ func plugin_handle_resource(quest: Quest) -> void:
 	
 	files_tree.select_quest(id, false)
 	display_quest(id)
+	quest_tree.select_quest(false)
 
 
 func display_quest(quest_id: int) -> void:
@@ -598,8 +598,20 @@ func load_quest_data() -> void:
 				quest_resource.custom_data[data_key],
 				true)
 	
-	events_tree.add_data("Success Events", quest_resource.on_success_events, events_tree.get_root(), false, false, false)
-	events_tree.add_data("Failure Events", quest_resource.on_failure_events, events_tree.get_root(), false, false, false)
+	var success_events: Dictionary[String, Variant] = {}
+	var failure_events: Dictionary[String, Variant] = {}
+	
+	if quest_resource.events.has(&"success"):
+		success_events = quest_resource.events[&"success"]
+	if quest_resource.events.has(&"failure"):
+		failure_events = quest_resource.events[&"failure"]
+	
+	events_tree.add_data(
+			"Success Events",
+			success_events)
+	events_tree.add_data(
+			"Failure Events",
+			failure_events)
 
 
 func load_stage_data(stage_id: StringName) -> void:
@@ -626,8 +638,20 @@ func load_stage_data(stage_id: StringName) -> void:
 				stage.custom_data[data_key],
 				true)
 	
-	events_tree.add_data("Success Events", stage.on_success_events, events_tree.get_root(), false, false, false)
-	events_tree.add_data("Failure Events", stage.on_failure_events, events_tree.get_root(), false, false, false)
+	var success_events: Dictionary[String, Variant] = {}
+	var failure_events: Dictionary[String, Variant] = {}
+	
+	if stage.events.has(&"success"):
+		success_events = stage.events[&"success"]
+	if stage.events.has(&"failure"):
+		failure_events = stage.events[&"failure"]
+	
+	events_tree.add_data(
+			"Success Events",
+			success_events)
+	events_tree.add_data(
+			"Failure Events",
+			failure_events)
 	
 	selected_stage = stage_id
 	selected_objective = &""
@@ -660,8 +684,20 @@ func load_objective_data(stage_id: StringName, objective_id: StringName) -> void
 	
 	obj_req_chk_bx.set_pressed_no_signal(quest_resource.get_stage(stage_id).is_objective_required(objective_id))
 	
-	events_tree.add_data("Success Events", objective.on_success_events, events_tree.get_root(), false, false, false)
-	events_tree.add_data("Failure Events", objective.on_failure_events, events_tree.get_root(), false, false, false)
+	var success_events: Dictionary[String, Variant] = {}
+	var failure_events: Dictionary[String, Variant] = {}
+	
+	if objective.events.has(&"success"):
+		success_events = objective.events[&"success"]
+	if objective.events.has(&"failure"):
+		failure_events = objective.events[&"failure"]
+	
+	events_tree.add_data(
+			"Success Events",
+			success_events)
+	events_tree.add_data(
+			"Failure Events",
+			failure_events)
 	
 	selected_stage = stage_id
 	selected_objective = objective_id
@@ -734,18 +770,19 @@ func open_quest_file(file_path: String) -> void:
 
 
 func add_quest_resource(quest: Quest) -> void:
+	var instance_id: int = quest.get_instance_id()
 	var quest_undo: UndoRedo = UndoRedo.new()
 	var data_undo: UndoRedo = UndoRedo.new()
 	var structure: Array[Dictionary] = get_layout_config_for_file(quest.resource_path)
 	
-	_open_files[quest.get_instance_id()] = {
+	_open_files[instance_id] = {
 		"resource": quest,
 		"quest_undo": quest_undo,
 		"data_undo": data_undo,
 		"structure": structure}
 	
 	files_tree.add_quest(
-			quest,
+			instance_id,
 			quest.resource_path)
 
 
@@ -782,7 +819,7 @@ func _get_layout_config(config_path: String) -> Array[Dictionary]:
 	
 	for item in value:
 		if typeof(item) == TYPE_DICTIONARY:
-			structure.append(value)
+			structure.append(item)
 	
 	return structure
 

--- a/addons/nexus_forge/quests/new_odyssey_script.gd
+++ b/addons/nexus_forge/quests/new_odyssey_script.gd
@@ -10,6 +10,10 @@ enum QuestModeType {
 
 const MAX_UNDO_STEPS: int = 50
 
+static var quest_path: String = ""
+static var stage_path: String = ""
+static var objecive_path: String = ""
+
 var quest_mode: QuestModeType = QuestModeType.NONE
 var quest_resource: Quest = null
 var undo: UndoRedo = null
@@ -52,6 +56,32 @@ var _open_files: Dictionary[int, Dictionary] = {}
 @onready var add_req_bool_button: Button = $MainContainer/DataContainer/DataContainer/LogicContainer/TargetLogicContainer/RequirementsCotnainer/HeaderContainer/AddButtonsContainer/AddReqBoolButton
 @onready var add_req_string_button: Button = $MainContainer/DataContainer/DataContainer/LogicContainer/TargetLogicContainer/RequirementsCotnainer/HeaderContainer/AddButtonsContainer/AddReqStringButton
 @onready var obj_req_tree: Tree = $MainContainer/DataContainer/DataContainer/LogicContainer/TargetLogicContainer/RequirementsCotnainer/ObjReqTree
+
+
+static func _static_init() -> void:
+	update_script_path()
+
+
+static func update_script_path(quest: bool = true, stage: bool = true, objective: bool = true) -> void:
+	if not quest and not stage and not objective:
+		return
+	
+	var all_classes: Array[Dictionary] = ProjectSettings.get_global_class_list()
+	for class_entry in all_classes:
+		if class_entry["class"] == "Quest":
+			if quest:
+				quest_path = class_entry["path"]
+		elif class_entry["class"] == "QuestStage":
+			if stage:
+				stage_path = class_entry["path"]
+		elif class_entry["class"] == "QuestObjective":
+			if objective:
+				objecive_path = class_entry["path"]
+		
+		if (not quest_path.is_empty() or not quest) and\
+				(not stage_path.is_empty() or not stage) and\
+				(not objecive_path.is_empty() or not objective):
+			break
 
 
 func _ready() -> void:
@@ -164,14 +194,21 @@ func ready_plugin() -> void:
 
 
 func filesystem_resource_removed(quest: Quest) -> void:
-	if files_tree.has_quest(quest):
-		files_tree.close_quest(quest)
-		if quest_resource == quest:
-			quest_resource = null
-			quest_mode = QuestModeType.NONE
-			set_quest_mode(QuestModeType.NONE)
-			custom_data_tree.clear_data()
-			events_tree.clear_data()
+	var quest_id: int = quest.get_instance_id()
+	if not _open_files.has(quest_id):
+		return
+	
+	if quest_resource == quest:
+		quest_resource = null
+		quest_mode = QuestModeType.NONE
+		set_quest_mode(QuestModeType.NONE)
+		custom_data_tree.clear_data()
+		events_tree.clear_data()
+	
+	_open_files[quest_id]["quest_undo"].free()
+	_open_files[quest_id]["data_undo"].free()
+	_open_files.erase(quest_id)
+	files_tree.close_quest(quest)
 
 
 func update_type_button(type: int) -> void:
@@ -187,7 +224,25 @@ func update_type_button(type: int) -> void:
 
 
 func set_quest_types(reselect: bool = false) -> void:
-	var quest_constants: Dictionary = Quest.new().get_script().get_script_constant_map()
+	if not FileAccess.file_exists(quest_path):
+		update_script_path(true, false, false)
+		if not FileAccess.file_exists(quest_path):
+			NFPluginGameHandler._log_msg(
+					"odyssey - editor",
+					"Unable to update quest types. Script not found.",
+					NFPluginGameHandler._LogLevel.ERROR)
+			return
+	
+	var script: Script = load(quest_path)
+	
+	if script == null:
+		NFPluginGameHandler._log_msg(
+				"odyssey - editor",
+				"Unable to update quest types. Unable to load script.",
+				NFPluginGameHandler._LogLevel.ERROR)
+		return
+	
+	var quest_constants: Dictionary = script.get_script_constant_map()
 	
 	if not quest_constants.has(&"QuestType"):
 		type_opt_btn.clear()
@@ -216,7 +271,25 @@ func set_quest_types(reselect: bool = false) -> void:
 
 
 func set_stage_types(reselect: bool = false) -> void:
-	var stage_constants: Dictionary = QuestStage.new().get_script().get_script_constant_map()
+	if not FileAccess.file_exists(stage_path):
+		update_script_path(false, true, false)
+		if not FileAccess.file_exists(stage_path):
+			NFPluginGameHandler._log_msg(
+					"odyssey - editor",
+					"Unable to update stage types. Script not found.",
+					NFPluginGameHandler._LogLevel.ERROR)
+			return
+	
+	var script: Script = load(stage_path)
+	
+	if script == null:
+		NFPluginGameHandler._log_msg(
+				"odyssey - editor",
+				"Unable to update stage types. Unable to load script.",
+				NFPluginGameHandler._LogLevel.ERROR)
+		return
+	
+	var stage_constants: Dictionary = script.get_script_constant_map()
 	
 	if not stage_constants.has(&"StageType"):
 		type_opt_btn.clear()
@@ -245,7 +318,25 @@ func set_stage_types(reselect: bool = false) -> void:
 
 
 func set_objective_types(reselect: bool = false) -> void:
-	var objectitve_constants: Dictionary = QuestObjective.new().get_script().get_script_constant_map()
+	if not FileAccess.file_exists(objecive_path):
+		update_script_path(false, true, false)
+		if not FileAccess.file_exists(objecive_path):
+			NFPluginGameHandler._log_msg(
+					"odyssey - editor",
+					"Unable to update objective types. Script not found.",
+					NFPluginGameHandler._LogLevel.ERROR)
+			return
+	
+	var script: Script = load(objecive_path)
+	
+	if script == null:
+		NFPluginGameHandler._log_msg(
+				"odyssey - editor",
+				"Unable to update objective types. Unable to load script.",
+				NFPluginGameHandler._LogLevel.ERROR)
+		return
+	
+	var objectitve_constants: Dictionary = script.get_script_constant_map()
 	
 	if not objectitve_constants.has(&"ObjectiveType"):
 		type_opt_btn.clear()
@@ -370,6 +461,7 @@ func set_stage_target_pointers(pointers: Array[StringName], reselect: bool = fal
 func select_success_pointer(target: StringName) -> void:
 	for idx in range(success_pointer_opt_btn.item_count):
 		if success_pointer_opt_btn.get_item_metadata(idx) == target:
+			success_pointer_opt_btn.set_meta(&"old_value", target)
 			success_pointer_opt_btn.select(idx)
 			return
 
@@ -377,6 +469,7 @@ func select_success_pointer(target: StringName) -> void:
 func select_failure_pointer(target: StringName) -> void:
 	for idx in range(failure_pointer_opt_btn.item_count):
 		if failure_pointer_opt_btn.get_item_metadata(idx) == target:
+			failure_pointer_opt_btn.set_meta(&"old_value", target)
 			failure_pointer_opt_btn.select(idx)
 			return
 
@@ -445,14 +538,15 @@ func save_current_quest() -> void:
 func plugin_handle_resource(quest: Quest) -> void:
 	if quest_resource != null and quest != quest_resource:
 		save_current_quest()
-		files_tree.set_quest_structure(quest_resource, quest_tree.get_quest_structure())
+		_open_files[quest_resource.get_instance_id()]["structure"] = quest_tree.get_quest_structure()
 	
 	var id: int = quest.get_instance_id()
 	
-	if _open_files.has(id):
-		files_tree.select_quest(id, false)
-	else:
+	if not _open_files.has(id):
 		add_quest_resource(quest)
+	
+	files_tree.select_quest(id, false)
+	display_quest(id)
 
 
 func display_quest(quest_id: int) -> void:
@@ -476,6 +570,7 @@ func select_type(type: int) -> void:
 	for idx in range(type_opt_btn.item_count):
 		if type_opt_btn.get_item_metadata(idx) == type:
 			type_opt_btn.select(idx)
+			type_opt_btn.set_meta(&"old_value", type)
 			return
 
 
@@ -581,11 +676,14 @@ func has_unsaved_files() -> bool:
 func save_resource() -> void:
 	if quest_resource != null:
 		save_current_quest()
-		files_tree.set_quest_structure(quest_resource, quest_tree.get_quest_structure())
+		_open_files[quest_resource.get_instance_id()]["structure"] = quest_tree.get_quest_structure()
 	
-	for quest_file:Dictionary in files_tree.get_unsaved_files():
-		_save_cfg_for(quest_file["resource"].resource_path, quest_file["structure"])
-		ResourceSaver.save(quest_file["resource"])
+	for unsaved_entries:Dictionary in files_tree.get_unsaved_files():
+		var file: Quest = _open_files[unsaved_entries["id"]]["resource"]
+		_save_cfg_for(
+			file.resource_path,
+			_open_files[unsaved_entries["id"]]["structure"])
+		ResourceSaver.save(file)
 	files_tree.set_all_saved()
 
 
@@ -601,11 +699,17 @@ func _save_cfg_for(filepath: String, structure: Array[Dictionary]) -> void:
 		DirAccess.make_dir_recursive_absolute(absolute_path)
 	
 	if cfg.save(absolute_path.path_join(cfg_filename)) != OK:
-		push_error("Error saving editor state on: ", absolute_path.path_join(cfg_filename))
+		NFPluginGameHandler._log_msg(
+				"odyssey - editor",
+				"Unable to save editor state to '%s'" % absolute_path.path_join(cfg_filename),
+				NFPluginGameHandler._LogLevel.WARNING)
 
 
 func get_open_files() -> Array[String]:
-	return files_tree.get_open_quest_paths()
+	var files: Array[String] = []
+	for file_id in _open_files:
+		files.append(_open_files[file_id]["resource"].resource_path)
+	return files
 
 
 func open_files(paths: Array[String]) -> void:
@@ -623,7 +727,7 @@ func open_quest_file(file_path: String) -> void:
 	
 	var res_id: int = res.get_instance_id()
 	
-	if files_tree.has_quest_file(res.resource_path) or _open_files.has(res_id):
+	if _open_files.has(res_id):
 		return
 	
 	add_quest_resource(res)
@@ -748,6 +852,9 @@ func _on_stage_id_changed(from: StringName, to: StringName) -> void:
 	quest_resource._stages[to] = quest_resource._stages[from]
 	quest_resource._stages.erase(from)
 	
+	if quest_resource.entry_stage == from:
+		quest_resource.entry_stage = to
+	
 	if selected_stage == from:
 		selected_stage = to
 	
@@ -793,6 +900,9 @@ func _on_quest_resource_selected(quest_id: int) -> void:
 
 
 func _on_objective_rearranged(from_stage: StringName, to_stage: StringName, objective_id: StringName) -> void:
+	if from_stage == to_stage:
+		return
+	
 	var stage_source: QuestStage = quest_resource.get_stage(from_stage)
 	var stage_target: QuestStage = quest_resource.get_stage(to_stage)
 	var objective: QuestObjective = stage_source.get_objective(objective_id)

--- a/addons/nexus_forge/quests/new_odyssey_script.gd
+++ b/addons/nexus_forge/quests/new_odyssey_script.gd
@@ -106,8 +106,34 @@ func _input(event: InputEvent) -> void:
 				return
 		
 		if event.keycode == KEY_Z:
+			if event.shift_pressed:
+				if undo.has_redo():
+					var action_name: String = undo.get_action_name(undo.get_current_action() + 1)
+					undo.redo()
+					NFPluginGameHandler._log_msg(
+						"",
+						"Redo: " + action_name,
+						NFPluginGameHandler._LogLevel.EDITOR)
+					_on_something_changed()
+			else:
+				if undo.has_undo():
+					var action_name: String = undo.get_current_action_name()
+					undo.undo()
+					NFPluginGameHandler._log_msg(
+						"",
+						"Undo: " + action_name,
+						NFPluginGameHandler._LogLevel.EDITOR)
+					_on_something_changed()
 			get_viewport().set_input_as_handled()
 		elif event.keycode == KEY_Y and not event.shift_pressed:
+			if undo.has_redo():
+				var action_name: String = undo.get_action_name(undo.get_current_action() + 1)
+				undo.redo()
+				NFPluginGameHandler._log_msg(
+					"",
+					"Redo: " + action_name,
+					NFPluginGameHandler._LogLevel.EDITOR)
+				_on_something_changed()
 			get_viewport().set_input_as_handled()
 
 

--- a/addons/nexus_forge/quests/new_odyssey_script.gd
+++ b/addons/nexus_forge/quests/new_odyssey_script.gd
@@ -146,21 +146,6 @@ func ready_plugin() -> void:
 	
 	quest_search_ln_edit.text_changed.connect(_on_search_quest_text_changed)
 	
-	quest_tree.quest_selected.connect(_on_quest_root_selected)
-	quest_tree.stage_selected.connect(_on_stage_selected)
-	quest_tree.objective_selected.connect(_on_objective_selected)
-	quest_tree.stage_created.connect(_on_stage_created)
-	quest_tree.objective_created.connect(_on_objective_created)
-	quest_tree.quest_id_changed.connect(_on_quest_id_changed)
-	quest_tree.stage_id_changed.connect(_on_stage_id_changed)
-	quest_tree.objective_id_changed.connect(_on_objective_id_changed)
-	quest_tree.objective_rearranged.connect(_on_objective_rearranged)
-	quest_tree.stage_erased.connect(_on_stage_erased)
-	quest_tree.objective_erased.connect(_on_objective_erased)
-	quest_tree.entry_stage_selected.connect(_on_entry_stage_selected)
-	quest_tree.stage_duplicated.connect(_on_stage_duplicated)
-	quest_tree.objective_duplicated.connect(_on_objective_duplicated)
-	
 	edit_types_btn.pressed.connect(_on_edit_types_pressed)
 	
 	add_int_button.pressed.connect(_on_add_custom_data_pressed.bind("new_int", 0))
@@ -181,16 +166,60 @@ func ready_plugin() -> void:
 	add_req_string_button.pressed.connect(_add_quest_requirement_data_pressed.bind(""))
 	
 	# Unsaved triggers
-	#obj_req_tree.data_changed.connect(_on_something_changed)
-	custom_data_tree.data_changed.connect(_on_something_changed)
-	#events_tree.data_changed.connect(_on_something_changed)
-	type_opt_btn.item_selected.connect(_on_something_changed)
 	title_ln_edt.text_changed.connect(_on_something_changed)
 	description_txt_edt.text_changed.connect(_on_something_changed)
-	obj_req_chk_bx.pressed.connect(_on_something_changed)
 	success_pointer_opt_btn.item_selected.connect(_on_something_changed)
 	failure_pointer_opt_btn.item_selected.connect(_on_something_changed)
-	quest_tree.tree_changed.connect(_on_something_changed)
+	
+	title_ln_edt.editing_toggled.connect(_on_title_edit_toggled)
+	description_txt_edt.focus_exited.connect(_on_description_focus_lost)
+	type_opt_btn.item_selected.connect(_on_quest_type_selected)
+	obj_req_chk_bx.toggled.connect(_on_objective_required_toggled)
+	custom_data_tree.data_changed.connect(_on_custom_data_changed)
+	
+	# Creation
+	quest_tree.stage_created.connect(_on_stage_created)
+	quest_tree.objective_created.connect(_on_objective_created)
+	
+	# Renaming
+	quest_tree.quest_id_changed.connect(_on_quest_id_changed)
+	quest_tree.stage_id_changed.connect(_on_stage_id_changed)
+	quest_tree.objective_id_changed.connect(_on_objective_id_changed)
+	
+	# Deletion
+	quest_tree.stage_erased.connect(_on_stage_erased)
+	quest_tree.objective_erased.connect(_on_objective_erased)
+	
+	# Movement
+	quest_tree.stage_moved.connect(_on_stage_moved)
+	quest_tree.objective_moved.connect(_on_objective_moved)
+	
+	# Duplication
+	quest_tree.stage_duplicated.connect(_on_stage_duplicated)
+	quest_tree.objective_duplicated.connect(_on_objective_duplicated)
+	
+	# Specialty
+	quest_tree.entry_stage_selected.connect(_on_entry_stage_selected)
+	
+	# Selection & UI
+	quest_tree.quest_selected.connect(_on_quest_root_selected)
+	quest_tree.stage_selected.connect(_on_stage_selected)
+	quest_tree.objective_selected.connect(_on_objective_selected)
+	
+	# Events Tree Connections
+	events_tree.data_created.connect(_on_event_data_created)
+	events_tree.data_moved.connect(_on_event_data_moved)
+	events_tree.data_renamed.connect(_on_event_data_renamed)
+	events_tree.data_updated.connect(_on_event_data_updated)
+	events_tree.data_erased.connect(_on_event_data_erased)
+
+	# Objective Requirements Tree Connections
+	obj_req_tree.data_created.connect(_on_objective_data_created)
+	obj_req_tree.data_moved.connect(_on_objective_data_moved)
+	obj_req_tree.data_renamed.connect(_on_objective_data_renamed)
+	obj_req_tree.data_updated.connect(_on_objective_data_updated)
+	obj_req_tree.data_erased.connect(_on_objective_data_erased)
+	obj_req_tree.data_operator_changed.connect(_on_data_data_operator_changed)
 
 
 func filesystem_resource_removed(quest: Quest) -> void:
@@ -421,9 +450,18 @@ func set_stage_target_disabled(target: StringName) -> void:
 				disabled)
 
 
+func update_stage_target_pointers(reselect: bool = true) -> void:
+	var new_pointers: Array[StringName] = []
+	new_pointers.assign(quest_resource.stages())
+	new_pointers.sort_custom(
+			func (a: StringName,b: StringName):
+				return a.naturalnocasecmp_to(String(b)) < 0)
+	set_stage_target_pointers(new_pointers, reselect)
+
+
 func set_stage_target_pointers(pointers: Array[StringName], reselect: bool = false) -> void:
-	var reselect_success: bool = success_pointer_opt_btn.selected != -1
-	var reselect_failure: bool = failure_pointer_opt_btn.selected != -1
+	var reselect_success: bool = success_pointer_opt_btn.selected != -1 if reselect else false
+	var reselect_failure: bool = failure_pointer_opt_btn.selected != -1 if reselect else false
 	var success_id: StringName = success_pointer_opt_btn.get_selected_metadata() if reselect_success else &""
 	var failure_id: StringName = failure_pointer_opt_btn.get_selected_metadata() if reselect_failure else &""
 	
@@ -550,18 +588,20 @@ func plugin_handle_resource(quest: Quest) -> void:
 
 
 func display_quest(quest_id: int) -> void:
-	if not _open_files.has(quest_id):
+	if not _open_files.has(quest_id) or _open_files[quest_id]["resource"] == quest_resource:
 		return
 	
-	var quest: Quest = _open_files[quest_id]["resource"]
+	if quest_resource != null:
+		save_current_quest()
 	
-	var pointers: Array[StringName] = []
-	pointers.assign(quest.stages())
-	pointers.sort_custom(ArrayUtils.sort_custom_alphabetically_asc)
-	set_stage_target_pointers(pointers)
-	quest_tree.set_quest(quest)
-	quest_tree.set_quest_structure(_open_files[quest_id]["structure"])
+	var quest: Quest = _open_files[quest_id]["resource"]
 	quest_resource = quest
+	undo = _open_files[quest_id]["quest_undo"]
+	custom_data_tree.set_undo(_open_files[quest_id]["data_undo"])
+	quest_tree.set_quest(quest, true, false)
+	quest_tree.set_quest_structure(_open_files[quest_id]["structure"])
+	update_stage_target_pointers(false)
+	
 	set_quest_mode(QuestModeType.QUEST)
 	load_quest_data()
 
@@ -857,83 +897,8 @@ func _on_objective_selected(stage_id: StringName, objective_id: StringName) -> v
 	load_objective_data(stage_id, objective_id)
 
 
-func _on_stage_created(stage_id: StringName) -> void:
-	var new_stage: QuestStage = QuestStage.new()
-	new_stage.id = stage_id
-	quest_resource.add_stage(new_stage)
-	var pointers: Array[StringName] = []
-	pointers.assign(quest_resource.stages())
-	pointers.sort_custom(ArrayUtils.sort_custom_alphabetically_asc)
-	set_stage_target_pointers(pointers, true)
-	_on_something_changed()
-
-
-func _on_objective_created(stage_id: StringName, objective_id: StringName) -> void:
-	var new_objective: QuestObjective = QuestObjective.new()
-	
-	new_objective.id = objective_id
-	quest_resource.get_stage(stage_id).add_objective(new_objective, true)
-	_on_something_changed()
-
-
-func _on_quest_id_changed(_from: StringName, to: StringName) -> void:
-	quest_resource.id = to
-	_on_something_changed()
-	update_crumbs_label()
-
-
-func _on_stage_id_changed(from: StringName, to: StringName) -> void:
-	if from == to:
-		return
-	quest_resource.get_stage(from).id = to
-	quest_resource._stages[to] = quest_resource._stages[from]
-	quest_resource._stages.erase(from)
-	
-	if quest_resource.entry_stage == from:
-		quest_resource.entry_stage = to
-	
-	if selected_stage == from:
-		selected_stage = to
-	
-	update_crumbs_label()
-	
-	_on_something_changed() 
-
-
-func _on_objective_id_changed(on_stage: StringName, from: StringName, to: StringName) -> void:
-	if from == to:
-		return
-	
-	var obj_dict: Dictionary = quest_resource.get_stage(on_stage)._objectives
-	obj_dict[from]["objective"].id = to
-	obj_dict[to] = obj_dict[from]
-	obj_dict.erase(from)
-	
-	if selected_stage == on_stage and selected_objective == from:
-		selected_objective = to
-	
-	update_crumbs_label()
-	
-	_on_something_changed()
-
-
 func _on_quest_resource_selected(quest_id: int) -> void:
-	if quest_resource != null:
-		save_current_quest()
-	
-	var resource: Quest = _open_files[quest_id]["resource"]
-	quest_resource = resource
-	undo = _open_files[quest_id]["quest_undo"]
-	custom_data_tree.set_undo(_open_files[quest_id]["data_undo"])
-	quest_tree.set_quest(resource, true, false)
-	quest_tree.set_quest_structure(_open_files[quest_id]["structure"])
-	
-	var stages: Array[StringName] = resource.stages()
-	stages.sort_custom(func(a:StringName,b:StringName): return a.naturalnocasecmp_to(String(b)) < 0)
-	
-	set_stage_target_pointers(stages)
-	
-	load_quest_data()
+	display_quest(quest_id)
 
 
 func _on_objective_rearranged(from_stage: StringName, to_stage: StringName, objective_id: StringName) -> void:
@@ -982,7 +947,8 @@ func _on_new_quest_file_pressed() -> void:
 		var old_id: int = cached_resource.get_instance_id()
 		take_over = true
 		if _open_files.has(old_id):
-			_open_files[old_id]["undo"].free()
+			_open_files[old_id]["quest_undo"].free()
+			_open_files[old_id]["data_undo"].free()
 			_open_files.erase(old_id)
 			files_tree.remove_quest(old_id)
 	else:
@@ -1013,11 +979,8 @@ func _on_new_quest_file_pressed() -> void:
 			true, # Select
 			false) # Emit Select
 	
+	update_stage_target_pointers(false)
 	load_quest_data() # Loads the quest data
-	var pointers: Array[StringName] = []
-	pointers.assign(new_quest.stages())
-	pointers.sort_custom(ArrayUtils.sort_custom_alphabetically_asc)
-	set_stage_target_pointers(pointers)
 
 
 func _on_search_files_text_changed(text: String) -> void:
@@ -1087,31 +1050,8 @@ func _on_quest_close_pressed(quest_id: int, requires_save: bool, structure: Arra
 	_open_files.erase(quest_id)
 
 
-func _on_stage_erased(stage_id: StringName) -> void:
-	quest_resource.remove_stage(stage_id)
-	if selected_stage == stage_id and selected_objective == &"":
-		quest_tree.select_quest()
-		load_quest_data()
-	_on_something_changed()
-
-
-func _on_objective_erased(from_stage: StringName, objective_id: StringName) -> void:
-	quest_resource.get_stage(from_stage).remove_objective(objective_id)
-	
-	if selected_stage == from_stage and selected_objective == objective_id:
-		quest_tree.select_stage(selected_stage, false)
-		load_stage_data(from_stage)
-	
-	_on_something_changed()
-
-
 func _on_add_custom_data_pressed(id: String, data) -> void:
 	custom_data_tree.add_data(id, data)
-	_on_something_changed()
-
-
-func _on_entry_stage_selected(stage_id: StringName) -> void:
-	quest_resource.entry_stage = stage_id
 	_on_something_changed()
 
 
@@ -1225,26 +1165,1041 @@ func _on_edit_types_pressed() -> void:
 				EditorInterface.set_main_screen_editor("Script")
 
 
-func _on_stage_duplicated(from: StringName, duplicate_id: StringName) -> void:
-	var stage: QuestStage = quest_resource.get_stage(from).duplicate(true)
-	stage.id = duplicate_id
-	quest_resource.add_stage(stage)
-	_on_something_changed()
-
-
-func _on_objective_duplicated(from_stage: StringName, objective_id: StringName, duplicate_id: StringName) -> void:
-	var stage: QuestStage = quest_resource.get_stage(from_stage)
-	var objective: QuestObjective = stage.get_objective(objective_id).duplicate(true)
-	objective.id = duplicate_id
-	
-	stage.add_objective(objective, stage.is_objective_required(objective_id))
-	_on_something_changed()
-
-
 # ------ UNDO/REDO ------
 
-func _on_quest_type_selected() -> void:
-	pass
+func switch_to(stage: StringName = &"", objective: StringName = &"") -> void:
+	if selected_stage == stage and selected_objective == objective:
+		return
+	
+	save_current_quest()
+	if stage.is_empty() and objective.is_empty():
+		load_quest_data()
+	elif objective.is_empty():
+		load_stage_data(stage)
+	else:
+		load_objective_data(stage, objective)
+
+
+func _on_quest_type_selected(type: int) -> void:
+	var new_value: int = type_opt_btn.get_item_metadata(type)
+	var old_value: int = type_opt_btn.get_meta(&"old_value")
+	
+	if new_value == old_value:
+		return
+	
+	type_opt_btn.set_meta(&"old_value", new_value)
+	
+	undo.create_action("Set Quest Type")
+	undo.add_do_method(_do_update_quest_type.bind(new_value))
+	undo.add_undo_method(_do_update_quest_type.bind(old_value))
+	undo.commit_action(false)
+	
+	_on_something_changed()
+
+
+func _do_update_quest_type(type: int) -> void:
+	switch_to()
+	select_type(type)
+
+
+func _on_title_edit_toggled(is_toggled: bool) -> void:
+	if is_toggled:
+		return
+	
+	var new_value: String = title_ln_edt.text
+	var old_value: String = title_ln_edt.get_meta(&"old_value")
+	
+	if new_value == old_value:
+		return
+	
+	title_ln_edt.set_meta(&"old_value", new_value)
+	
+	var action_title: String = ""
+	
+	if selected_stage.is_empty() and selected_objective.is_empty():
+		action_title = "Set Quest Title"
+	elif selected_objective.is_empty():
+		action_title = "Set Stage '%s' Objective '%s' Title" % [selected_stage, selected_objective]
+	else:
+		action_title = "Set Stage '%s' Title" % selected_stage
+	
+	undo.create_action(action_title)
+	undo.add_do_method(_do_set_title_of.bind(
+			selected_stage,
+			selected_objective,
+			new_value))
+	undo.add_undo_method(_do_set_title_of.bind(
+			selected_stage,
+			selected_objective,
+			old_value))
+	undo.commit_action(false)
+
+
+func _do_set_title_of(stage: StringName, objective: StringName, title: String) -> void:
+	switch_to(stage, objective)
+	
+	title_ln_edt.text = title
+	title_ln_edt.set_meta(&"old_value", title)
+
+
+func _on_description_focus_lost() -> void:
+	var new_value: String = description_txt_edt.text
+	var old_value: String = description_txt_edt.get_meta(&"old_value")
+	
+	if new_value == old_value:
+		return
+	
+	description_txt_edt.set_meta(&"old_value", new_value)
+	
+	var action_title: String = ""
+	
+	if selected_stage.is_empty() and selected_objective.is_empty():
+		action_title = "Set Quest Description"
+	elif selected_objective.is_empty():
+		action_title = "Set Stage '%s' Objective '%s' Description" % [selected_stage, selected_objective]
+	else:
+		action_title = "Set Stage '%s' Description" % selected_stage
+	
+	undo.create_action(action_title)
+	undo.add_do_method(_do_set_description_of.bind(
+			selected_stage,
+			selected_objective,
+			new_value))
+	undo.add_undo_method(_do_set_description_of.bind(
+			selected_stage,
+			selected_objective,
+			old_value))
+	undo.commit_action(false)
+
+
+func _do_set_description_of(stage: StringName, objective: StringName, title: String) -> void:
+	switch_to(stage, objective)
+	
+	description_txt_edt.text = title
+	description_txt_edt.set_meta(&"old_value", title)
+
+
+func _on_custom_data_changed() -> void:
+	if custom_data_tree.has_undo():
+		var action_name: String = ""
+		if selected_stage.is_empty() and selected_objective.is_empty():
+			action_name = "Set Quest Data"
+		elif selected_objective.is_empty():
+			action_name = "Set '%s' Stage '%s' Objective Data" % [selected_stage, selected_objective]
+		else:
+			action_name = "Set '%s' Stage Data" % selected_stage
+		
+		undo.create_action(action_name)
+		undo.add_do_method(_do_custom_data_change.bind(
+				selected_stage,
+				selected_objective))
+		undo.add_undo_method(_undo_custom_data_change.bind(
+				selected_stage,
+				selected_objective))
+	_on_something_changed()
+
+
+func _do_custom_data_change(stage: StringName, objective: StringName) -> void:
+	switch_to(stage, objective)
+	custom_data_tree.redo()
+
+
+func _undo_custom_data_change(stage: StringName, objective: StringName) -> void:
+	switch_to(stage, objective)
+	custom_data_tree.undo()
+
+
+func _on_event_data_created(path: String, index: int , data: Variant) -> void:
+	var type: int = typeof(data)
+	var can_dupe: bool = type == TYPE_DICTIONARY or type == TYPE_ARRAY
+	var action_name: String = ""
+	
+	if selected_stage.is_empty() and selected_objective.is_empty():
+		action_name = "Set Quest Event"
+	elif selected_objective.is_empty():
+		action_name = "Set Stage '%s' Event" % selected_stage
+	else:
+		action_name = "Set Stage '%s' Objective '%s' Event" % [selected_stage, selected_objective]
+	
+	undo.create_action(action_name)
+	undo.add_do_method(_do_create_event_data.bind(
+			selected_stage,
+			selected_objective,
+			path,
+			data.duplicate(true) if can_dupe else data,
+			index))
+	undo.add_undo_method(_undo_create_event_data.bind(
+			selected_stage,
+			selected_objective,
+			path))
+	undo.commit_action(false)
+	_on_something_changed()
+
+
+func _do_create_event_data(stage: StringName, objective: StringName, path: String, data: Variant, index: int) -> void:
+	switch_to(stage, objective)
+	events_tree._do_add_data(
+		path,
+		data,
+		index)
+
+
+func _undo_create_event_data(stage: StringName, objective: StringName, path: String) -> void:
+	switch_to(stage, objective)
+	events_tree._undo_add_data(path)
+
+
+func _on_event_data_moved(from_path: String, from_index: int, to_path: String, to_index: int) -> void:
+	var action_name: String = ""
+	
+	if selected_stage.is_empty() and selected_objective.is_empty():
+		action_name = "Move Quest Event"
+	elif selected_objective.is_empty():
+		action_name = "Move Stage '%s' Event" % selected_stage
+	else:
+		action_name = "Move Stage '%s' Objective '%s' Event" % [selected_stage, selected_objective]
+	
+	undo.create_action(action_name)
+	undo.add_do_method(_do_move_event_data.bind(
+			selected_stage,
+			selected_objective,
+			from_path,
+			to_path,
+			to_index))
+	undo.add_undo_method(_do_move_event_data.bind(
+			selected_stage,
+			selected_objective,
+			to_path,
+			from_path,
+			from_index))
+	undo.commit_action(false)
+	
+	_on_something_changed()
+
+
+func _do_move_event_data(stage: StringName, objective: StringName, from_path: String, to_path: String, to_index: int) -> void:
+	switch_to(stage, objective)
+	events_tree._do_move_item(
+			from_path,
+			to_path,
+			to_index)
+
+
+func _on_event_data_renamed(parent_path: String, old_name: String, new_name: String) -> void:
+	var action_name: String = ""
+	if selected_stage.is_empty() and selected_objective.is_empty():
+		action_name = "Set Quest Event ID"
+	elif selected_objective.is_empty():
+		action_name = "Set Stage '%s' Event ID" % selected_stage
+	else:
+		action_name = "Set Stage '%s' Objective '%s' Event ID" % [selected_stage, selected_objective]
+	
+	undo.create_action(action_name)
+	undo.add_do_method(_do_rename_event.bind(
+			selected_stage,
+			selected_objective,
+			parent_path.path_join(old_name),
+			new_name))
+	undo.add_undo_method(_do_rename_event.bind(
+			selected_stage,
+			selected_objective,
+			parent_path.path_join(new_name),
+			old_name))
+	undo.commit_action(false)
+	
+	_on_something_changed()
+
+
+func _do_rename_event(stage: StringName, objective: StringName, path: String, new_name: String) -> void:
+	switch_to(stage, objective)
+	events_tree._do_rename_item(path, new_name)
+
+
+func _on_event_data_updated(path: String, old_value: Variant, new_value: Variant) -> void:
+	var action_name: String = ""
+	if selected_stage.is_empty() and selected_objective.is_empty():
+		action_name = "Set Quest Event Data"
+	elif selected_objective.is_empty():
+		action_name = "Set Stage '%s' Event Data" % selected_stage
+	else:
+		action_name = "Set Stage '%s' Objective '%s' Event Data" % [selected_stage, selected_objective]
+	
+	undo.create_action(action_name)
+	undo.add_do_method(_do_update_event_data.bind(
+			selected_stage,
+			selected_objective,
+			path,
+			new_value))
+	undo.add_undo_method(_do_update_event_data.bind(
+			selected_stage,
+			selected_objective,
+			path,
+			old_value))
+	undo.commit_action(false)
+	
+	_on_something_changed()
+
+
+func _do_update_event_data(stage: StringName, objective: StringName, path: String, data: Variant) -> void:
+	switch_to(stage, objective)
+	events_tree._do_update_item_data(
+			path,
+			data)
+
+
+func _on_event_data_erased(path: String, index: int, data: Variant) -> void:
+	var action_name: String = ""
+	var type: int = typeof(data)
+	var can_dupe: bool = type == TYPE_DICTIONARY or type == TYPE_ARRAY
+	
+	if selected_stage.is_empty() and selected_objective.is_empty():
+		action_name = "Erase Quest Event Data"
+	elif selected_objective.is_empty():
+		action_name = "Erase Stage '%s' Event Data" % selected_stage
+	else:
+		action_name = "Erase Stage '%s' Objective '%s' Event Data" % [selected_stage, selected_objective]
+	
+	undo.create_action(action_name)
+	undo.add_do_method(_do_erase_event.bind(
+			selected_stage,
+			selected_objective,
+			path))
+	undo.add_undo_method(_undo_erase_event.bind(
+			selected_stage,
+			selected_objective,
+			path,
+			data.duplicate(true) if can_dupe else data,
+			index))
+	undo.commit_action(false)
+	
+	_on_something_changed()
+
+
+func _do_erase_event(stage: StringName, objective: StringName, path: String) -> void:
+	switch_to(stage, objective)
+	events_tree._do_erase_data(path)
+
+
+func _undo_erase_event(stage: StringName, objective: StringName, path: String, data: Variant, index: int) -> void:
+	switch_to(stage, objective)
+	events_tree._undo_erase_data(
+			path,
+			data,
+			index)
+
+
+func _on_objective_data_created(path: String, index: int , data: Variant, operator: int) -> void:
+	var type: int = typeof(data)
+	var can_dupe: bool = type == TYPE_DICTIONARY or type == TYPE_ARRAY
+	undo.create_action("Add Objective '%s' Requirement" % selected_objective)
+	undo.add_do_method(_do_create_objective_data.bind(
+			selected_stage,
+			selected_objective,
+			path,
+			data.duplicate(true) if can_dupe else data,
+			operator,
+			index))
+	undo.add_undo_method(_undo_create_objective_data.bind(
+			selected_stage,
+			selected_objective,
+			path))
+	_on_something_changed()
+
+
+func _do_create_objective_data(stage: StringName, objective: StringName, path: String, data: Variant, operator: int, index: int) -> void:
+	switch_to(stage, objective)
+	obj_req_tree._do_add_data(
+			path,
+			data,
+			operator,
+			index)
+
+
+func _undo_create_objective_data(stage: StringName, objective: StringName, path: String) -> void:
+	switch_to(stage, objective)
+	obj_req_tree._undo_add_data(path)
+
+
+func _on_objective_data_moved(from_path: String, from_index: int, to_path: String, to_index: int) -> void:
+	undo.create_action("Move Objective '%s' Requirement" % selected_objective)
+	undo.add_do_method(_do_move_objective_data.bind(
+			selected_stage,
+			selected_objective,
+			from_path,
+			to_path,
+			to_index))
+	undo.add_undo_method(_do_move_objective_data.bind(
+			selected_stage,
+			selected_objective,
+			to_path,
+			from_path,
+			from_index))
+	undo.commit_action(false)
+	
+	_on_something_changed()
+
+
+func _do_move_objective_data(stage: StringName, objective: StringName, from_path: String, to_path: String, to_index: int) -> void:
+	switch_to(stage, objective)
+	obj_req_tree._do_move_item(
+			from_path,
+			to_path,
+			to_index)
+
+
+func _on_objective_data_renamed(parent_path: String, old_name: String, new_name: String) -> void:
+	undo.create_action("Set Objective '%s' Requirement ID" % selected_objective)
+	undo.add_do_method(_do_rename_objecive_requirement.bind(
+			selected_stage,
+			selected_objective,
+			parent_path.path_join(old_name),
+			new_name))
+	undo.add_undo_method(_do_rename_objecive_requirement.bind(
+			selected_stage,
+			selected_objective,
+			parent_path.path_join(new_name),
+			old_name))
+	undo.commit_action(false)
+	
+	_on_something_changed()
+
+
+func _do_rename_objecive_requirement(stage: StringName, objective: StringName, path: String, new_name: String) -> void:
+	switch_to(stage, objective)
+	obj_req_tree._do_rename_item(path, new_name)
+
+
+func _on_objective_data_updated(path: String, old_value: Variant, new_value: Variant) -> void:
+	undo.create_action("Set Objective '%s' Requirement Data" % selected_objective)
+	undo.add_do_method(_do_update_objective_requirement_data.bind(
+		selected_stage,
+		selected_objective,
+		path,
+		new_value))
+	undo.add_undo_method(_do_update_objective_requirement_data.bind(
+		selected_stage,
+		selected_objective,
+		path,
+		old_value))
+	undo.commit_action(false)
+	_on_something_changed()
+
+
+func _do_update_objective_requirement_data(stage: StringName, objective: StringName, path: String, data: Variant) -> void:
+	switch_to(stage, objective)
+	obj_req_tree._do_update_item_data(
+			path,
+			data)
+
+
+func _on_objective_data_erased(path: String, index: int, data: Variant, operator: int) -> void:
+	var type: int = typeof(data)
+	var can_dupe: bool = type == TYPE_DICTIONARY or type == TYPE_ARRAY
+	
+	undo.create_action("Erase Objective '%s' Requirement Data" % selected_objective)
+	undo.add_do_method(_do_erase_objective_requirement.bind(
+		selected_stage,
+		selected_objective,
+		path))
+	undo.add_undo_method(_undo_erase_objective_requirement.bind(
+			selected_stage,
+			selected_objective,
+			path,
+			data.duplicate(true) if can_dupe else data,
+			operator,
+			index))
+	undo.commit_action(false)
+	
+	_on_something_changed()
+
+
+func _do_erase_objective_requirement(stage: StringName, objective: StringName, path: String) -> void:
+	switch_to(stage, objective)
+	obj_req_tree._do_erase_data(path)
+
+
+func _undo_erase_objective_requirement(stage: StringName, objective: StringName, path: String, data: Variant, operator: int, index: int) -> void:
+	switch_to(stage, objective)
+	obj_req_tree._undo_erase_data(
+			path,
+			data,
+			operator,
+			index)
+
+
+func _on_data_data_operator_changed(path: String, old_operator: int, new_operator: int) -> void:
+	undo.create_action("Set Objective '%s' Requirement Operator" % selected_objective)
+	undo.add_do_method(_do_update_objective_operator.bind(
+			selected_stage,
+			selected_objective,
+			path,
+			new_operator))
+	undo.add_undo_method(_do_update_objective_operator.bind(
+			selected_stage,
+			selected_objective,
+			path,
+			old_operator))
+	undo.commit_action(false)
+	
+	_on_something_changed()
+
+
+func _do_update_objective_operator(stage: StringName, objective: StringName, path: String, operator: int) -> void:
+	switch_to(stage, objective)
+	obj_req_tree.set_data_operator(path, operator)
+
+
+func _on_objective_required_toggled(is_toggled: bool) -> void:
+	undo.create_action("Set Stage '%s' Objective '%s' Required" % [selected_stage, selected_objective])
+	undo.add_do_method(_do_update_objective_required.bind(
+			selected_stage,
+			selected_objective,
+			is_toggled))
+	undo.add_undo_method(_do_update_objective_required.bind(
+			selected_stage,
+			selected_objective,
+			not is_toggled))
+	undo.commit_action(false)
+	_on_something_changed()
+
+
+func _do_update_objective_required(stage: StringName, objective: StringName, is_required: bool) -> void:
+	switch_to(stage, objective)
+	obj_req_chk_bx.set_pressed_no_signal(is_required)
+
+
+func _on_stage_created(stage_id: StringName) -> void:
+	var new_stage: QuestStage = QuestStage.new()
+	new_stage.id = stage_id
+	quest_resource.add_stage(new_stage)
+	
+	update_stage_target_pointers()
+	
+	undo.create_action("Create Stage '%s'" % stage_id)
+	undo.add_do_method(_do_create_stage.bind(stage_id))
+	undo.add_undo_method(_undo_create_stage.bind(stage_id))
+	undo.commit_action(false)
+	
+	_on_something_changed()
+
+
+func _do_create_stage(stage_id: StringName) -> void:
+	var new_stage: QuestStage = QuestStage.new()
+	new_stage.id = stage_id
+	quest_resource.add_stage(new_stage)
+	quest_tree.add_stage(stage_id)
+	
+	update_stage_target_pointers()
+
+
+func _undo_create_stage(stage_id: StringName) -> void:
+	quest_resource.remove_stage(stage_id)
+	quest_tree.erase_stage(stage_id)
+	
+	update_stage_target_pointers()
+	
+	if selected_stage == stage_id:
+		quest_tree.select_quest(false)
+		load_quest_data()
+
+
+func _on_objective_created(stage_id: StringName, objective_id: StringName) -> void:
+	var new_objective: QuestObjective = QuestObjective.new()
+	new_objective.id = objective_id
+	quest_resource.get_stage(stage_id).add_objective(new_objective, true)
+	
+	undo.create_action("Create Stage '%s' Objective '%s'" % [stage_id, objective_id])
+	undo.add_do_method(_do_create_objective.bind(stage_id, objective_id))
+	undo.add_undo_method(_undo_create_objective.bind(stage_id, objective_id))
+	undo.commit_action(false)
+	
+	_on_something_changed()
+
+
+func _do_create_objective(on_stage: StringName, objective_id: StringName) -> void:
+	var new_objective: QuestObjective = QuestObjective.new()
+	new_objective.id = objective_id
+	quest_resource.get_stage(on_stage).add_objective(new_objective, true)
+	quest_tree.add_objective(on_stage, objective_id)
+
+
+func _undo_create_objective(on_stage: StringName, objective_id: StringName) -> void:
+	var stage: QuestStage = quest_resource.get_stage(on_stage)
+	if stage != null:
+		stage.remove_objective(objective_id)
+	quest_tree.erase_objective(on_stage, objective_id)
+	
+	if selected_stage == on_stage and selected_objective == objective_id:
+		quest_tree.select_stage(on_stage, false)
+		load_stage_data(on_stage)
+
+
+func _on_quest_id_changed(from: StringName, to: StringName) -> void:
+	undo.create_action("Set Quest ID")
+	undo.add_do_method(_do_update_quest_id.bind(to))
+	undo.add_undo_method(_do_update_quest_id.bind(from))
+	undo.commit_action()
+	_on_something_changed()
+
+
+func _do_update_quest_id(to: StringName) -> void:
+	quest_resource.id = to
+	update_crumbs_label()
+
+
+func _on_stage_id_changed(from: StringName, to: StringName) -> void:
+	if quest_resource.has_stage(from):
+		quest_resource.get_stage(from).id = to
+		quest_resource._stages[to] = quest_resource._stages[from]
+		quest_resource._stages.erase(from)
+	
+	if quest_resource.entry_stage == from:
+		quest_resource.entry_stage = to
+	
+	if selected_stage == from:
+		selected_stage = to
+		update_crumbs_label()
+	
+	undo.create_action("Set Stage ID")
+	undo.add_do_method(_do_update_stage_id.bind(from, to))
+	undo.add_undo_method(_do_update_stage_id.bind(to, from))
+	undo.commit_action(false)
+	
+	_on_something_changed() 
+
+
+func _do_update_stage_id(from: StringName, to: StringName) -> void:
+	if not quest_resource.has_stage(from):
+		NFPluginGameHandler._log_msg(
+				"odyssey - editor",
+				"Couldn't set ID of stage '%s'. Stage not found",
+				NFPluginGameHandler._LogLevel.ERROR)
+		return
+	
+	quest_resource.get_stage(from).id = to
+	quest_resource._stages[to] = quest_resource._stages[from]
+	quest_resource._stages.erase(from)
+	
+	quest_tree.set_stage_id(from, to)
+	
+	if quest_resource.entry_stage == from:
+		quest_resource.entry_stage = to
+	
+	if selected_stage == from:
+		selected_stage = to
+		update_crumbs_label()
+
+
+func _on_objective_id_changed(on_stage: StringName, from: StringName, to: StringName) -> void:
+	if not quest_resource.has_stage(on_stage):
+		NFPluginGameHandler._log_msg(
+				"odyssey - editor",
+				"Couldn't set objective '%s' ID. Stage '%s' not found",
+				NFPluginGameHandler._LogLevel.ERROR)
+		return
+	elif not quest_resource.get_stage(on_stage).has_objective(from):
+		NFPluginGameHandler._log_msg(
+				"odyssey - editor",
+				"Couldn't set objective '%s' ID. Objective not found",
+				NFPluginGameHandler._LogLevel.ERROR)
+		return
+	
+	var obj_dict: Dictionary = quest_resource.get_stage(on_stage)._objectives
+	obj_dict[from]["objective"].id = to
+	obj_dict[to] = obj_dict[from]
+	obj_dict.erase(from)
+	
+	if selected_stage == on_stage and selected_objective == from:
+		selected_objective = to
+		update_crumbs_label()
+	
+	undo.create_action("Set Objective ID")
+	undo.add_do_method(_do_update_objective_id.bind(on_stage, from, to))
+	undo.add_undo_method(_do_update_objective_id.bind(on_stage, to, from))
+	undo.commit_action(false)
+	
+	_on_something_changed()
+
+
+func _do_update_objective_id(on_stage: StringName, from: StringName, to: StringName) -> void:
+	if not quest_resource.has_stage(on_stage):
+		NFPluginGameHandler._log_msg(
+				"odyssey - editor",
+				"Couldn't set objective '%s' ID. Stage '%s' not found",
+				NFPluginGameHandler._LogLevel.ERROR)
+		return
+	elif not quest_resource.get_stage(on_stage).has_objective(from):
+		NFPluginGameHandler._log_msg(
+				"odyssey - editor",
+				"Couldn't set objective '%s' ID. Objective not found",
+				NFPluginGameHandler._LogLevel.ERROR)
+		return
+	
+	var obj_dict: Dictionary = quest_resource.get_stage(on_stage)._objectives
+	obj_dict[from]["objective"].id = to
+	obj_dict[to] = obj_dict[from]
+	obj_dict.erase(from)
+	
+	quest_tree.set_objective_id(on_stage, from, to)
+	
+	if selected_stage == on_stage and selected_objective == from:
+		selected_objective = to
+		update_crumbs_label()
+
+
+func _on_entry_stage_selected(stage_id: StringName) -> void:
+	var old_entry: StringName = quest_resource.entry_stage
+	quest_resource.entry_stage = stage_id
+	undo.create_action("Set Entry Stage")
+	undo.add_do_method(_do_update_entry_stage.bind(stage_id))
+	undo.add_undo_method(_do_update_entry_stage.bind(old_entry))
+	undo.commit_action(false)
+	_on_something_changed()
+
+
+func _do_update_entry_stage(stage_id: StringName) -> void:
+	if not stage_id.is_empty() and not quest_resource.has_stage(stage_id):
+		NFPluginGameHandler._log_msg(
+				"odyssey - editor",
+				"Can't set entry stage to '%s'. Stage not found",
+				NFPluginGameHandler._LogLevel.ERROR)
+		return
+	
+	quest_resource.entry_stage = stage_id
+	quest_tree.set_entry_stage(stage_id)
+
+
+func _on_stage_duplicated(from: StringName, duplicate_id: StringName) -> void:
+	var stage_obj: QuestStage = quest_resource.get_stage(from)
+	var duplicate_obj: QuestStage = stage_obj.duplicate(true)
+	duplicate_obj.id = duplicate_id
+	# --- Godot 4.4 Compatibility code ---
+	# A quest stage saves objectives as subresoruces. To ensure duplication
+	# is true we will go and duplicate the resources too. This is solved in
+	# Godot 4.5, but NexusForge 1.X will support 4.4. On version 2.0, supported
+	# versions will be changed just ahead enough to solve old issues like this.
+	for objective_id in duplicate_obj.objectives():
+		var original_obj: QuestObjective = stage_obj.get_objective(objective_id)
+		duplicate_obj._objectives[objective_id]["objective"] = original_obj.duplicate(true)
+	# ------------------------------------
+	quest_resource.add_stage(duplicate_obj)
+	
+	update_stage_target_pointers()
+	
+	undo.create_action("Duplicate Stage '%s'" % from)
+	undo.add_do_method(_do_duplicate_stage.bind(from, duplicate_id))
+	undo.add_undo_method(_undo_duplicate_stage.bind(duplicate_id))
+	undo.commit_action(false)
+	
+	_on_something_changed()
+
+
+func _do_duplicate_stage(target: StringName, new_id: StringName) -> void:
+	if not quest_resource.has_stage(target):
+		NFPluginGameHandler._log_msg(
+				"odyssey - editor",
+				"Failed to duplicate stage '%s'. Stage not found" % target,
+				NFPluginGameHandler._LogLevel.ERROR)
+		return
+	elif quest_resource.has_stage(new_id):
+		NFPluginGameHandler._log_msg(
+				"odyssey - editor",
+				"Failed to duplicate stage '%s' with new ID '%s'. ID already assigned" % [target, new_id],
+				NFPluginGameHandler._LogLevel.ERROR)
+		return
+	
+	var stage_obj: QuestStage = quest_resource.get_stage(target)
+	var duplicate_obj: QuestStage = quest_resource.duplicate(true)
+	duplicate_obj.id = new_id
+	# --- Godot 4.4 Compatibility code ---
+	# A quest stage saves objectives as subresoruces. To ensure duplication
+	# is true we will go and duplicate the resources too. This is solved in
+	# Godot 4.5, but NexusForge 1.X will support 4.4. On version 2.0, supported
+	# versions will be changed just ahead enough to solve old issues like this.
+	for objective_id in duplicate_obj.objectives():
+		var original_obj: QuestObjective = stage_obj.get_objective(objective_id)
+		duplicate_obj._objectives[objective_id]["objective"] = original_obj.duplicate(true)
+	# ------------------------------------
+	
+	quest_resource.add_stage(duplicate_obj)
+	quest_tree.add_stage(new_id)
+	update_stage_target_pointers()
+
+
+func _undo_duplicate_stage(duplicate_id: StringName) -> void:
+	if not quest_resource.has_stage(duplicate_id):
+		return
+	
+	quest_resource.remove_stage(duplicate_id)
+	quest_tree.erase_stage(duplicate_id)
+	update_stage_target_pointers()
+	if selected_stage == duplicate_id:
+		load_quest_data()
+
+
+func _on_objective_duplicated(from_stage: StringName, objective: StringName, duplicate_id: StringName) -> void:
+	var stage: QuestStage = quest_resource.get_stage(from_stage)
+	var objective_dupe: QuestObjective = stage.get_objective(objective).duplicate(true)
+	objective_dupe.id = duplicate_id
+	stage.add_objective(objective_dupe, stage.is_objective_required(objective))
+	
+	undo.create_action("Duplicate Stage '%s' Objective '%s'" % [from_stage, objective])
+	undo.add_do_method(_do_duplicate_objective.bind(from_stage, objective, duplicate_id))
+	undo.add_undo_method(_undo_duplicate_objective.bind(from_stage, duplicate_id))
+	undo.commit_action(false)
+	
+	_on_something_changed()
+
+
+func _do_duplicate_objective(from_stage: StringName, objective_id: StringName, duplicate_id: StringName) -> void:
+	if not quest_resource.has_stage(from_stage):
+		NFPluginGameHandler._log_msg(
+				"odyssey - editor",
+				"Failed to duplicate objective '%s' from stage '%s'. Stage not found" % [objective_id, from_stage],
+				NFPluginGameHandler._LogLevel.ERROR)
+		return
+	
+	var stage: QuestStage = quest_resource.get_stage(from_stage)
+	
+	if not stage.has_objective(objective_id):
+		NFPluginGameHandler._log_msg(
+			"odyssey - editor",
+			"Failed to duplicate objective '%s' from stage '%s'. Objective not found" % [objective_id, from_stage],
+			NFPluginGameHandler._LogLevel.ERROR)
+		return
+	elif stage.has_objective(duplicate_id):
+		NFPluginGameHandler._log_msg(
+				"odyssey - editor",
+				"Failed to duplicate objective '%s' with new ID '%s'. ID already assigned" % [objective_id, duplicate_id],
+				NFPluginGameHandler._LogLevel.ERROR)
+		return
+	
+	var duplicate_objective: QuestObjective = stage.get_objective(objective_id).duplicate(true)
+	duplicate_objective.id = duplicate_id
+	stage.add_objective(duplicate_objective, stage.is_objective_required(objective_id))
+	
+	quest_tree.add_objective(from_stage, duplicate_id)
+
+
+func _undo_duplicate_objective(on_stage: StringName, objective_id: StringName) -> void:
+	if not quest_resource.has_stage(on_stage):
+		return
+	
+	var target: QuestStage = quest_resource.get_stage(on_stage)
+	
+	if not target.has_objective(objective_id):
+		return
+	
+	target.remove_objective(objective_id)
+	quest_tree.erase_objective(on_stage, objective_id)
+	if selected_stage == on_stage and selected_objective == objective_id:
+		load_stage_data(on_stage)
+
+
+func _on_stage_moved(stage_id: StringName, from_index: int, to_index: int) -> void:
+	undo.create_action("Move Stage '%s'" % stage_id)
+	undo.add_do_method(_do_move_stage.bind(stage_id, to_index))
+	undo.add_undo_method(_do_move_stage.bind(stage_id, from_index))
+	undo.commit_action(false)
+	_on_something_changed()
+
+
+func _do_move_stage(stage_id: StringName, to_index: int) -> void:
+	quest_tree.move_stage(stage_id, to_index)
+
+
+func _on_objective_moved(objective_id: StringName, from_stage: StringName, from_index: int, to_stage: StringName, to_index: int) -> void:
+	undo.create_action("Move Stage '%s' Objective '%s'" % [from_stage, objective_id])
+	undo.add_do_method(_do_move_objective.bind(
+			objective_id,
+			from_stage,
+			to_stage,
+			to_index))
+	undo.add_undo_method(_do_move_objective.bind(
+			objective_id,
+			to_stage,
+			from_stage,
+			from_index))
+	undo.commit_action(false)
+	_on_something_changed()
+
+
+func _do_move_objective(objective_id: StringName, from_stage: StringName, to_stage: StringName, to_index: int) -> void:
+	quest_tree.move_objective(
+			objective_id,
+			from_stage,
+			to_stage,
+			to_index)
+
+
+func _on_stage_erased(stage_id: StringName, index: int) -> void:
+	var original_stage: QuestStage = quest_resource.get_stage(stage_id)
+	var duplicate_stage: QuestStage = original_stage.duplicate(true)
+	# --- Godot 4.4 Compatibility code ---
+	# A quest stage saves objectives as subresoruces. To ensure duplication
+	# is true we will go and duplicate the resources too. This is solved in
+	# Godot 4.5, but NexusForge 1.X will support 4.4. On version 2.0, supported
+	# versions will be changed just ahead enough to solve old issues like this.
+	for objective_id in original_stage.objectives():
+		var original_obj: QuestObjective = original_stage.get_objective(objective_id)
+		var dupe_objective: QuestObjective = original_obj.duplicate(true)
+		duplicate_stage._objectives[objective_id]["objective"] = dupe_objective
+	# ------------------------------------
+	var targeted_stages: Dictionary[StringName, Dictionary] = {}
+	# {"on_success": true, "on_failure": false}
+	
+	for id in quest_resource.stages():
+		if id == stage_id:
+			continue
+		var stg: QuestStage = quest_resource.get_stage(id)
+		var success_match: bool = false
+		var failure_match: bool = false
+		
+		if stg.success_stage_id == stage_id:
+			success_match = true
+			stg.success_stage_id = &""
+		
+		if stg.failure_stage_id == stage_id:
+			failure_match = true
+			stg.failure_stage_id = &""
+		
+		if success_match or failure_match:
+			if not targeted_stages.has(id):
+				targeted_stages[id] = DictUtils.create_typed(TYPE_STRING, TYPE_BOOL)
+			targeted_stages[id]["on_success"] = success_match
+			targeted_stages[id]["on_failure"] = failure_match
+	
+	quest_resource.remove_stage(stage_id)
+	if selected_stage == stage_id:
+		quest_tree.select_quest(false)
+		load_quest_data()
+	
+	undo.create_action("Erase Stage '%s'" % stage_id)
+	undo.add_do_method(_do_erase_stage.bind(stage_id))
+	undo.add_undo_method(_undo_erase_stage.bind(
+			duplicate_stage,
+			index,
+			targeted_stages))
+	undo.commit_action(false)
+	
+	_on_something_changed()
+
+
+func _undo_erase_stage(stage_res: QuestStage, index: int, pointers_patch: Dictionary[StringName, Dictionary]) -> void:
+	if quest_resource.has_stage(stage_res.id):
+		NFPluginGameHandler._log_msg(
+				"odyssey - editor",
+				"Failed to restore stage '%s'. Stage already exists" % stage_res.id,
+				NFPluginGameHandler._LogLevel.ERROR)
+		return
+	
+	var restored_stage: QuestStage = stage_res.duplicate(true)
+	# --- Godot 4.4 Compatibility code ---
+	# A quest stage saves objectives as subresoruces. To ensure duplication
+	# is true we will go and duplicate the resources too. This is solved in
+	# Godot 4.5, but NexusForge 1.X will support 4.4. On version 2.0, supported
+	# versions will be changed just ahead enough to solve old issues like this.
+	for objective_id in stage_res.objectives():
+		var saved_objective: QuestObjective = stage_res.get_objective(objective_id)
+		var restored_objective: QuestObjective = saved_objective.duplicate(true)
+		restored_stage._objectives[objective_id]["objective"] = restored_objective
+	# ------------------------------------
+	
+	for stage_id in quest_resource.stages():
+		if not pointers_patch.has(stage_id):
+			continue
+		var stage: QuestStage = quest_resource.get_stage(stage_id)
+		if pointers_patch[stage_id]["on_success"]:
+			stage.success_stage_id = stage_res.id
+		if pointers_patch[stage_id]["on_failure"]:
+			stage.failure_stage_id = stage_res.id
+	
+	quest_resource.add_stage(stage_res)
+	quest_tree.add_stage(stage_res.id, index)
+	
+	update_stage_target_pointers()
+
+
+func _do_erase_stage(stage_id: StringName) -> void:
+	if not quest_resource.has_stage(stage_id):
+		return
+	
+	for id in quest_resource.stages():
+		if id == stage_id:
+			continue
+		var stg: QuestStage = quest_resource.get_stage(id)
+		if stg.success_stage_id == stage_id:
+			stg.success_stage_id = &""
+		if stg.failure_stage_id == stage_id:
+			stg.failure_stage_id = &""
+	
+	quest_resource.remove_stage(stage_id)
+	quest_tree.erase_stage(stage_id)
+	if selected_stage == stage_id:
+		quest_tree.select_quest(false)
+		load_quest_data()
+
+
+func _on_objective_erased(from_stage: StringName, objective_id: StringName, index: int) -> void:
+	var stage: QuestStage = quest_resource.get_stage(from_stage)
+	var objective_backup: QuestObjective = stage.get_objective(objective_id).duplicate(true)
+	var is_required: bool = stage.is_objective_required(objective_id)
+	
+	stage.remove_objective(objective_id)
+	
+	if selected_stage == from_stage and selected_objective == objective_id:
+		quest_tree.select_stage(selected_stage, false)
+		load_stage_data(from_stage)
+	
+	undo.create_action("Erase Stage '%s' Objective '%s'" % [from_stage, objective_id])
+	undo.add_do_method(_do_erase_objective.bind(from_stage, objective_id))
+	undo.add_undo_method(_undo_erase_objective.bind(
+			from_stage,
+			objective_backup,
+			is_required,
+			index))
+	undo.commit_action(false)
+	
+	_on_something_changed()
+
+
+func _undo_erase_objective(on_stage: StringName, objective_res: QuestObjective, required: bool, index: int) -> void:
+	if not quest_resource.has_stage(on_stage):
+		NFPluginGameHandler._log_msg(
+				"odyssey - editor",
+				"Failed to restore objective on stage '%s'. Stage not found" % on_stage,
+				NFPluginGameHandler._LogLevel.ERROR)
+		return
+	
+	var stage: QuestStage = quest_resource.get_stage(on_stage)
+	
+	if stage.has_objective(objective_res.id):
+		NFPluginGameHandler._log_msg(
+				"odyssey - editor",
+				"Failed to restore objective '%s' on stage '%s'. Objective already exists" % [objective_res.id, on_stage],
+				NFPluginGameHandler._LogLevel.ERROR)
+		return
+	
+	var restored_objective: QuestObjective = objective_res.duplicate(true)
+	stage.add_objective(restored_objective, required)
+	quest_tree.add_objective(on_stage, objective_res.id, index)
+
+
+func _do_erase_objective(from_stage: StringName, objective_id: StringName) -> void:
+	if not quest_resource.has_stage(from_stage):
+		return
+	
+	var stage: QuestStage = quest_resource.get_stage(from_stage)
+	
+	if not stage.has_objective(objective_id):
+		return
+	
+	stage.remove_objective(objective_id)
+	quest_tree.erase_objective(from_stage, objective_id)
+	
+	if selected_stage == from_stage and selected_objective == objective_id:
+		quest_tree.select_stage(selected_stage, false)
+		load_stage_data(from_stage)
 
 
 func _notification(what: int) -> void:

--- a/addons/nexus_forge/quests/new_odyssey_script.gd
+++ b/addons/nexus_forge/quests/new_odyssey_script.gd
@@ -456,6 +456,9 @@ func set_ui_enabled(enabled: bool) -> void:
 	add_bool_button.disabled = disabled
 	add_string_button.disabled = disabled
 	add_dict_button.disabled = disabled
+	
+	search_event_ln_edt.editable = enabled
+	custom_data_search_line.editable = enabled
 
 
 func update_crumbs_label() -> void:
@@ -625,6 +628,8 @@ func display_quest(quest_id: int) -> void:
 	if quest_resource != null:
 		save_current_quest()
 	
+	quest_search_ln_edit.clear()
+	
 	var quest: Quest = _open_files[quest_id]["resource"]
 	quest_resource = quest
 	undo = _open_files[quest_id]["quest_undo"]
@@ -651,6 +656,8 @@ func load_quest_data() -> void:
 	
 	selected_stage = &""
 	selected_objective = &""
+	search_event_ln_edt.clear()
+	custom_data_search_line.clear()
 	
 	update_crumbs_label()
 	
@@ -690,6 +697,9 @@ func load_stage_data(stage_id: StringName) -> void:
 	
 	quest_mode = QuestModeType.STAGE
 	set_quest_mode(QuestModeType.STAGE)
+	
+	search_event_ln_edt.clear()
+	custom_data_search_line.clear()
 	
 	title_ln_edt.text = stage.title
 	title_ln_edt.set_meta(&"old_value", stage.title)
@@ -735,6 +745,9 @@ func load_objective_data(stage_id: StringName, objective_id: StringName) -> void
 	
 	quest_mode = QuestModeType.OBJECTIVE
 	set_quest_mode(QuestModeType.OBJECTIVE)
+	
+	search_event_ln_edt.clear()
+	custom_data_search_line.clear()
 	
 	title_ln_edt.text = objective.title
 	title_ln_edt.set_meta(&"old_value", objective.title)
@@ -1273,6 +1286,9 @@ func _do_set_title_of(stage: StringName, objective: StringName, title: String) -
 
 
 func _on_description_focus_lost() -> void:
+	if undo == null:
+		return
+	
 	var new_value: String = description_txt_edt.text
 	var old_value: String = description_txt_edt.get_meta(&"old_value")
 	

--- a/addons/nexus_forge/quests/new_odyssey_script.gd
+++ b/addons/nexus_forge/quests/new_odyssey_script.gd
@@ -46,6 +46,7 @@ var _open_files: Dictionary[int, Dictionary] = {}
 @onready var search_event_ln_edt: LineEdit = $MainContainer/DataContainer/DataContainer/LogicContainer/EventsContainer/EventsHeader/SearchEventLnEdt
 @onready var requirement_search_ln_edt: LineEdit = $MainContainer/DataContainer/DataContainer/LogicContainer/TargetLogicContainer/RequirementsCotnainer/HeaderContainer/RequirementSearchLnEdt
 @onready var edit_types_btn: Button = $MainContainer/DataContainer/DataContainer/BasicDataContainer/TypeContainer/EditTypesBtn
+@onready var events_header_label: Label = $MainContainer/DataContainer/DataContainer/LogicContainer/EventsContainer/EventsHeader/EventsHeaderLabel
 
 @onready var target_logic_container: VBoxContainer = $MainContainer/DataContainer/DataContainer/LogicContainer/TargetLogicContainer
 @onready var stage_logic_container: VBoxContainer = $MainContainer/DataContainer/DataContainer/LogicContainer/StageLogicContainer
@@ -425,12 +426,16 @@ func set_quest_mode(mode: QuestModeType) -> void:
 	$MainContainer/DataContainer/DataContainer/LogicContainer.collapsed = mode != QuestModeType.OBJECTIVE
 	
 	if mode == QuestModeType.QUEST:
+		events_header_label.text = "Quest Events"
 		set_quest_types()
 	elif mode == QuestModeType.STAGE:
+		events_header_label.text = "Stage Events"
 		set_stage_types()
 	elif mode == QuestModeType.OBJECTIVE:
+		events_header_label.text = "Objective Events"
 		set_objective_types()
 	else:
+		events_header_label.text = "Events"
 		type_opt_btn.clear()
 	
 	set_ui_enabled(mode != QuestModeType.NONE)
@@ -672,10 +677,10 @@ func load_quest_data() -> void:
 	if quest_resource.events.has(&"failure"):
 		failure_events = quest_resource.events[&"failure"]
 	
-	events_tree.add_data(
+	events_tree.add_constant_data(
 			"Success Events",
 			success_events)
-	events_tree.add_data(
+	events_tree.add_constant_data(
 			"Failure Events",
 			failure_events)
 
@@ -712,10 +717,10 @@ func load_stage_data(stage_id: StringName) -> void:
 	if stage.events.has(&"failure"):
 		failure_events = stage.events[&"failure"]
 	
-	events_tree.add_data(
+	events_tree.add_constant_data(
 			"Success Events",
 			success_events)
-	events_tree.add_data(
+	events_tree.add_constant_data(
 			"Failure Events",
 			failure_events)
 	
@@ -758,10 +763,10 @@ func load_objective_data(stage_id: StringName, objective_id: StringName) -> void
 	if objective.events.has(&"failure"):
 		failure_events = objective.events[&"failure"]
 	
-	events_tree.add_data(
+	events_tree.add_constant_data(
 			"Success Events",
 			success_events)
-	events_tree.add_data(
+	events_tree.add_constant_data(
 			"Failure Events",
 			failure_events)
 	
@@ -1023,8 +1028,7 @@ func _on_custom_data_search_text_changed(text: String) -> void:
 
 func _on_search_event_text_changed(text: String) -> void:
 	var clean_text: String = text.strip_edges()
-	for item in events_tree.get_root().get_children():
-		item.visible = events_tree._child_has_data(item, clean_text)
+	events_tree.search_data(clean_text)
 
 
 func _on_search_requirement_text_changed(text: String) -> void:

--- a/addons/nexus_forge/quests/new_quests.tscn
+++ b/addons/nexus_forge/quests/new_quests.tscn
@@ -399,7 +399,7 @@ size_flags_stretch_ratio = 2.0
 [node name="EventsHeader" type="HBoxContainer" parent="MainContainer/DataContainer/DataContainer/LogicContainer/EventsContainer" unique_id=1184923930]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="MainContainer/DataContainer/DataContainer/LogicContainer/EventsContainer/EventsHeader" unique_id=1361518937]
+[node name="EventsHeaderLabel" type="Label" parent="MainContainer/DataContainer/DataContainer/LogicContainer/EventsContainer/EventsHeader" unique_id=1361518937]
 layout_mode = 2
 text = "Quest Events"
 
@@ -407,6 +407,7 @@ text = "Quest Events"
 layout_mode = 2
 size_flags_horizontal = 3
 placeholder_text = "Search Event"
+clear_button_enabled = true
 
 [node name="EventsTree" type="Tree" parent="MainContainer/DataContainer/DataContainer/LogicContainer/EventsContainer" unique_id=277766728]
 layout_mode = 2

--- a/addons/nexus_forge/quests/new_quests.tscn
+++ b/addons/nexus_forge/quests/new_quests.tscn
@@ -252,6 +252,7 @@ hide_root = true
 script = ExtResource("5_v44ms")
 allow_drag_and_drop = true
 compact_mode = true
+undo_redo_steps = 0
 
 [node name="LogicContainer" type="VSplitContainer" parent="MainContainer/DataContainer/DataContainer" unique_id=149868027]
 custom_minimum_size = Vector2(300, 0)

--- a/addons/nexus_forge/quests/obj_req_tree_script.gd
+++ b/addons/nexus_forge/quests/obj_req_tree_script.gd
@@ -653,6 +653,7 @@ func _add_data_to_tree(new_name: String, data: Variant, operator: int, on_node: 
 		else:
 			new_data.set_range_config(1, 0, 1, 1)
 			new_data.set_text(1, "==,!=")
+		new_data.set_tooltip_text(1, "Comparator")
 		new_data.set_range(1, operator_to_range(operator))
 		new_data.set_editable(1, true)
 	else:

--- a/addons/nexus_forge/quests/obj_req_tree_script.gd
+++ b/addons/nexus_forge/quests/obj_req_tree_script.gd
@@ -2,11 +2,12 @@
 extends IDTree
 
 
-signal data_created(path: String, index: int ,data: Variant)
+signal data_created(path: String, index: int , data: Variant, operator: int)
 signal data_moved(from_path: String, from_index: int, to_path: String, to_index: int)
 signal data_renamed(parent_path: String, old_name: String, new_name: String)
 signal data_updated(path: String, old_value: Variant, new_value: Variant)
-signal data_erased(path: String, index: int, data: Variant)
+signal data_erased(path: String, index: int, data: Variant, operator: int)
+signal data_operator_changed(path: String, old_operator: int, new_operator: int)
 
 enum ItemType {
 	DATA,
@@ -488,45 +489,40 @@ func _do_update_item_data(path: String, data: Variant) -> void:
 	
 	var new_type: int = _data_type_to_internal(typeof(data))
 	
-	if new_type != item.get_metadata(1):
-		if item.get_metadata(1) == TYPE_DICTIONARY:
-			var btn_idx: int = item.get_button_by_id(1, ButtonIds.TYPE_MENU)
-			if btn_idx != -1:
-				item.erase_button(1, btn_idx)
+	if new_type != item.get_metadata(2):
 		match new_type:
 			TYPE_INT:
 				item.set_icon(0, ICON_INT)
-				item.set_metadata(1, TYPE_INT)
-				item.set_cell_mode(1, TreeItem.CELL_MODE_RANGE)
-				item.set_range_config(1, RANGE_FLOOR, RANGE_CEIL, 1.0)
-				item.set_range(1, data)
-				item.set_editable(1, true)
+				item.set_metadata(2, TYPE_INT)
+				item.set_cell_mode(2, TreeItem.CELL_MODE_RANGE)
+				item.set_range_config(2, RANGE_FLOOR, RANGE_CEIL, 1.0)
+				item.set_range(2, data)
+				item.set_editable(2, true)
 			TYPE_FLOAT:
 				item.set_icon(0, ICON_FLOAT)
-				item.set_metadata(1, TYPE_FLOAT)
-				item.set_cell_mode(1, TreeItem.CELL_MODE_RANGE)
-				item.set_range_config(1, RANGE_FLOOR, RANGE_CEIL, RANGE_FLOAT_STEP)
-				item.set_range(1, data)
-				item.set_editable(1, true)
+				item.set_metadata(2, TYPE_FLOAT)
+				item.set_cell_mode(2, TreeItem.CELL_MODE_RANGE)
+				item.set_range_config(2, RANGE_FLOOR, RANGE_CEIL, RANGE_FLOAT_STEP)
+				item.set_range(2, data)
+				item.set_editable(2, true)
 			TYPE_BOOL:
 				item.set_icon(0, ICON_BOOL)
-				item.set_metadata(1, TYPE_BOOL)
-				item.set_cell_mode(1, TreeItem.CELL_MODE_CHECK)
-				item.set_text(1, "Enabled")
-				item.set_checked(1, data)
-				item.set_editable(1, true)
+				item.set_metadata(2, TYPE_BOOL)
+				item.set_cell_mode(2, TreeItem.CELL_MODE_CHECK)
+				item.set_text(2, "Enabled")
+				item.set_checked(2, data)
+				item.set_editable(2, true)
 			TYPE_STRING:
 				item.set_icon(0, ICON_STRING)
-				item.set_metadata(1, TYPE_STRING)
-				item.set_cell_mode(1, TreeItem.CELL_MODE_STRING)
-				item.set_text(1, data)
-				item.set_editable(1, true)
+				item.set_metadata(2, TYPE_STRING)
+				item.set_cell_mode(2, TreeItem.CELL_MODE_STRING)
+				item.set_text(2, data)
+				item.set_editable(2, true)
 			TYPE_DICTIONARY:
 				item.set_icon(0, ICON_FOLDER)
-				item.set_metadata(1, TYPE_DICTIONARY)
-				item.set_selectable(1, false)
-				item.set_editable(0, true)
-				item.set_editable(1, false)
+				item.set_metadata(2, TYPE_DICTIONARY)
+				item.set_selectable(2, false)
+				item.set_editable(2, false)
 				item.get_metadata(0)["type"] = ItemType.FOLDER
 				if compact_mode:
 					item.add_button(
@@ -545,19 +541,19 @@ func _do_update_item_data(path: String, data: Variant) -> void:
 					add_data(subdata, data[subdata], false, item)
 			_:
 				item.set_icon(0, ICON_VARIABLE)
-				item.set_metadata(1, TYPE_NIL)
+				item.set_metadata(2, TYPE_NIL)
 				item.get_metadata(0)["data"] = data
-				item.set_cell_mode(1, TreeItem.CELL_MODE_STRING)
-				item.set_text(1, type_string(typeof(data)))
-				item.set_editable(1, false)
+				item.set_cell_mode(2, TreeItem.CELL_MODE_STRING)
+				item.set_text(2, type_string(typeof(data)))
+				item.set_editable(2, false)
 	else:
 		match new_type:
 			TYPE_INT, TYPE_FLOAT:
-				item.set_range(1, data)
+				item.set_range(2, data)
 			TYPE_BOOL:
-				item.set_checked(1, data)
+				item.set_checked(2, data)
 			TYPE_STRING:
-				item.set_text(1, data)
+				item.set_text(2, data)
 			_:
 				item.get_metadata(0)["data"] = data
 	
@@ -648,7 +644,7 @@ func _add_data_to_tree(new_name: String, data: Variant, operator: int, on_node: 
 	
 	if data_type != TYPE_DICTIONARY:
 		new_data.set_metadata(0, metadata)
-		
+		new_data.set_metadata(1, operator)
 		new_data.set_cell_mode(1, TreeItem.CELL_MODE_RANGE)
 		
 		if data_type == TYPE_INT or data_type == TYPE_FLOAT:
@@ -667,15 +663,15 @@ func _add_data_to_tree(new_name: String, data: Variant, operator: int, on_node: 
 
 
 func get_data_cell_data(cell: TreeItem) -> Variant:
-	match cell.get_metadata(1):
+	match cell.get_metadata(2):
 		TYPE_INT:
-			return int(cell.get_range(1))
+			return int(cell.get_range(2))
 		TYPE_FLOAT:
-			return float(cell.get_range(1))
+			return float(cell.get_range(2))
 		TYPE_BOOL:
-			return cell.is_checked(1)
+			return cell.is_checked(2)
 		TYPE_STRING:
-			return cell.get_text(1)
+			return cell.get_text(2)
 		TYPE_DICTIONARY:
 			var subfolder: Dictionary = {}
 			for sub_data in cell.get_children():
@@ -705,19 +701,19 @@ func _on_button_clicked(item: TreeItem, column: int, id: int, mouse_button_index
 			return
 		ButtonIds.INT:
 			data_copy = 0
-			data_path = add_data("new_int", 0, false, item)
+			data_path = add_data("new_int", 0, OP_EQUAL, item)
 		ButtonIds.FLOAT:
 			data_copy = 0.0
-			data_path = add_data("new_float", 0.0, false, item)
+			data_path = add_data("new_float", 0.0, OP_EQUAL, item)
 		ButtonIds.BOOL:
 			data_copy = false
-			data_path = add_data("new_bool", false, false, item)
+			data_path = add_data("new_bool", false, OP_EQUAL, item)
 		ButtonIds.STRING:
 			data_copy = ""
-			data_path = add_data("new_string", "", false, item)
+			data_path = add_data("new_string", "", OP_EQUAL, item)
 		ButtonIds.LEVEL:
 			data_copy = {}
-			data_path = add_data("new_folder", {}, false, item)
+			data_path = add_data("new_folder", {}, OP_EQUAL, item)
 		ButtonIds.TYPE_MENU:
 			data_item = item
 			mn.position = DisplayServer.mouse_get_position()
@@ -732,15 +728,47 @@ func _on_button_clicked(item: TreeItem, column: int, id: int, mouse_button_index
 func on_data_edited() -> void:
 	var edited: TreeItem = get_edited()
 	var path: String = _get_data_path(edited)
+	var column: int = get_edited_column()
 	
-	if get_edited_column() == 1: # Value
+	if column == 0: # --- ID updated ---
+		if edited.get_metadata(0)["name"] == edited.get_text(0):
+			return
+		
+		var old_name: String = edited.get_metadata(0)["name"]
+		var new_name: String = get_unique_id(edited.get_parent(), edited.get_text(0), edited)
+		
+		var parent_path: String = _get_data_path(edited.get_parent())
+		var old_path: String = parent_path.path_join(old_name)
+		var new_path: String = parent_path.path_join(new_name)
+		
+		edited.set_text(0, new_name)
+		edited.get_metadata(0)["name"] = new_name
+		
+		data_renamed.emit(
+				parent_path,
+				old_name,
+				new_name)
+	elif column == 1: # Operator
+		var old_value: int = edited.get_metadata(1)
+		var new_value: int = range_to_operator(edited.get_range(1))
+		
+		if new_value == old_value:
+			return
+		
+		edited.set_metadata(1, new_value)
+		data_operator_changed.emit(
+				path,
+				old_value,
+				new_value)
+	elif column == 2: # Value
 		var from = edited.get_metadata(0)["value"]
 		var to = get_data_cell_data(edited)
 		var emit_update: bool = true
 		
-		match edited.get_metadata(1):
+		match edited.get_metadata(2):
 			TYPE_INT, TYPE_FLOAT:
-				if edited.get_metadata(0)["value"] != int(edited.get_range(1)) if edited.get_metadata(1) == TYPE_INT else edited.get_range(1):
+				var current_val = int(edited.get_range(2)) if edited.get_metadata(2) == TYPE_INT else edited.get_range(2)
+				if edited.get_metadata(0)["value"] != current_val:
 					edited.get_metadata(0)["value"] = to
 				else:
 					emit_update = false
@@ -766,27 +794,6 @@ func on_data_edited() -> void:
 					path,
 					from,
 					to)
-		return
-	
-	# --- ID updated ---
-	
-	if edited.get_metadata(0)["name"] == edited.get_text(0):
-		return
-	
-	var old_name: String = edited.get_metadata(0)["name"]
-	var new_name: String = get_unique_id(edited.get_parent(), edited.get_text(0), edited)
-	
-	var parent_path: String = _get_data_path(edited.get_parent())
-	var old_path: String = parent_path.path_join(old_name)
-	var new_path: String = parent_path.path_join(new_name)
-	
-	edited.set_text(0, new_name)
-	edited.get_metadata(0)["name"] = new_name
-	
-	data_renamed.emit(
-			parent_path,
-			old_name,
-			new_name)
 
 
 func get_data() -> Dictionary[String, Dictionary]:
@@ -940,6 +947,13 @@ func get_cell_value(cell: TreeItem) -> Dictionary:
 			return {}
 
 
+func set_data_operator(path: String, operator: int) -> void:
+	var target: TreeItem = _get_data_item(path)
+	if target != null:
+		target.set_range(1, operator_to_range(operator))
+		target.set_metadata(1, operator)
+
+
 func _tree_has_id(item: TreeItem, id: String) -> bool:
 	for tree in item.get_children():
 		if tree.get_metadata(0)["name"] == id:
@@ -958,12 +972,12 @@ func _child_has_data(item: TreeItem, text: String) -> bool:
 
 
 func _data_cell_to_string(item: TreeItem) -> String:
-	match item.get_cell_mode(1):
+	match item.get_cell_mode(2):
 		TreeItem.CELL_MODE_STRING:
-			return item.get_text(1)
+			return item.get_text(2)
 		TreeItem.CELL_MODE_RANGE:
-			return str(item.get_range(1))
+			return str(item.get_range(2))
 		TreeItem.CELL_MODE_CHECK:
-			return "true" if item.is_checked(1) else "false"
+			return "true" if item.is_checked(2) else "false"
 		_:
 			return ""

--- a/addons/nexus_forge/quests/obj_req_tree_script.gd
+++ b/addons/nexus_forge/quests/obj_req_tree_script.gd
@@ -2,8 +2,11 @@
 extends IDTree
 
 
-signal item_deleted
-signal data_changed
+signal data_created(path: String, index: int ,data: Variant)
+signal data_moved(from_path: String, from_index: int, to_path: String, to_index: int)
+signal data_renamed(parent_path: String, old_name: String, new_name: String)
+signal data_updated(path: String, old_value: Variant, new_value: Variant)
+signal data_erased(path: String, index: int, data: Variant)
 
 enum ItemType {
 	DATA,
@@ -20,7 +23,8 @@ enum ButtonIds {
 	TYPE_MENU,
 }
 
-const RANGE_MAX: int = 9999
+const RANGE_CEIL: int = 9999
+const RANGE_FLOOR: int = -9999
 const RANGE_FLOAT_STEP: float = 0.01
 
 @export var allow_drag_and_drop: bool = false
@@ -53,6 +57,7 @@ func ready_plugin() -> void:
 	id_cell = 0
 	
 	create_item()
+	
 	set_column_title(0, "Data ID")
 	set_column_title(2, "Data Value")
 	
@@ -134,11 +139,11 @@ func _on_compact_menu_id_pressed(id: int) -> void:
 	else:
 		data_name += "data"
 	
-	add_data(data_name, data_type, OP_EQUAL, data_item)
+	var path: String = add_data(data_name, data_type, false, data_item)
 	
 	data_item = null
 	
-	data_changed.emit()
+	data_created.emit(path, -1, data_type)
 
 
 func _get_drag_data(at_position: Vector2) -> Variant:
@@ -150,7 +155,7 @@ func _get_drag_data(at_position: Vector2) -> Variant:
 	var preview: Label = Label.new()
 	preview.text = "    " + item.get_text(0)
 	set_drag_preview(preview)
-	return {"tree": item, "type": item.get_metadata(0)["type"], "source": "data_tree"}
+	return {"tree": item, "type": item.get_metadata(0)["type"], "source": "req_objective_tree"}
 
 
 func _can_drop_data(at_position: Vector2, data: Variant) -> bool:
@@ -161,9 +166,9 @@ func _can_drop_data(at_position: Vector2, data: Variant) -> bool:
 		drop_mode_flags = DROP_MODE_DISABLED
 		return false
 	
-	if data.has_all(["tree", "type", "source"]) and typeof(data["source"]) == TYPE_STRING and data["source"] == "data_tree":
+	if data.has_all(["tree", "type", "source"]) and typeof(data["source"]) == TYPE_STRING and data["source"] == "req_objective_tree":
 		var target_node: TreeItem = get_item_at_position(at_position)
-		if target_node == data["tree"] or (data["type"] == ItemType.FOLDER and _is_item_child_of(target_node, data["tree"])): #target_node.get_parent() == data["tree"]):
+		if target_node == data["tree"] or (data["type"] == ItemType.FOLDER and _is_item_child_of(target_node, data["tree"])):
 			drop_mode_flags = DROP_MODE_DISABLED
 			return false
 		
@@ -193,36 +198,145 @@ func _is_item_child_of(item: TreeItem, parent: TreeItem) -> bool:
 	return false
 
 
+func _do_move_item(from: String, to: String, index: int) -> void:
+	var target: TreeItem = null
+	var new_parent: TreeItem = null
+	var current_folder: TreeItem = get_root()
+	
+	var to_slice: PackedStringArray = to.split("/", false)
+	var from_slice: PackedStringArray = from.split("/", false)
+	
+	if to_slice.is_empty() or from_slice.is_empty():
+		return
+	
+	var new_name: String = to_slice[-1]
+	
+	for slice in to_slice.slice(0, -1):
+		var found: bool = false
+		for item in current_folder.get_children():
+			if item.get_metadata(0)["name"] == slice:
+				if item.get_metadata(0)["type"] == ItemType.FOLDER:
+					current_folder = item
+					found = true
+				break
+		if not found:
+			return
+	
+	new_parent = current_folder
+	
+	if new_parent != get_root() and new_parent.get_metadata(0)["type"] != ItemType.FOLDER:
+		return
+	
+	for item in new_parent.get_children():
+		if item.get_metadata(0)["name"] == new_name:
+			return
+	
+	current_folder = get_root()
+	
+	for slice in from_slice:
+		var found: bool = false
+		for item in current_folder.get_children():
+			if item.get_metadata(0)["name"] == slice:
+				current_folder = item
+				found = true
+				break
+		if not found:
+			return
+	
+	target = current_folder
+	
+	target.set_text(0, new_name)
+	target.get_metadata(0)["name"] = new_name
+	
+	if target.get_parent() != new_parent:
+		target.get_parent().remove_child(target)
+		new_parent.add_child(target)
+		if -1 < index and target.get_index() != index:
+			if new_parent.get_child_count() <= 1:
+				return
+			if index == 0:
+				target.move_before(new_parent.get_first_child())
+			else:
+				target.move_after(new_parent.get_child(index - 1))
+
+
+func _is_in_tree(item: TreeItem) -> bool:
+	var current_level: TreeItem = item
+	var root: TreeItem = get_root()
+	
+	while current_level != null:
+		current_level = current_level.get_parent()
+		if current_level == get_root():
+			return true
+	return false
+
+
 func _drop_data(at_position: Vector2, data: Variant) -> void:
 	if not allow_drag_and_drop:
 		return
 	
-	var target: TreeItem = get_item_at_position(at_position)
 	var object: TreeItem = data["tree"]
+	var drop_target: TreeItem = get_item_at_position(at_position)
+	var new_parent: TreeItem = null
+	var from_this_tree: bool = _is_in_tree(object)
+	var original_index: int = object.get_index()
+	var original_path: String = _get_data_path(object)
+	var new_index: int = -1
 	
-	if target == null:
-		var root_count: int = get_root().get_child_count()
-		if object.get_parent() == get_root():
-			if 0 < root_count - 1 and object.get_index() < root_count - 1:
-				object.move_after(get_root().get_child(-1))
-		else:
-			if 0 < root_count:
-				object.move_after(get_root().get_child(-1))
-			else:
-				object.get_parent().remove_child(object)
-				get_root().add_child(object)
+	if drop_target == null:
+		new_parent = get_root()
+		new_index = -1
 	else:
+		var same_parent_shift: bool = from_this_tree and\
+				object.get_parent() == drop_target.get_parent() and\
+				object.get_index() < drop_target.get_index()
 		var drop_position: int = get_drop_section_at_position(at_position)
-		
 		match drop_position:
 			-1: # Above
-				object.move_before(target)
+				new_parent = drop_target.get_parent()
+				new_index = drop_target.get_index()
+				if same_parent_shift:
+					new_index -= 1
 			0: # On
-				object.get_parent().remove_child(object)
-				target.add_child(object)
+				new_index = -1
+				new_parent = drop_target
 			1: # Below
-				object.move_after(target)
-	data_changed.emit()
+				if drop_target.get_metadata(0)["type"] == ItemType.FOLDER and not drop_target.collapsed and 0 < drop_target.get_child_count():
+					new_index = 0
+					new_parent = drop_target
+				else:
+					new_parent = drop_target.get_parent()
+					new_index = drop_target.get_index()
+					if not same_parent_shift:
+						new_index += 1
+	
+	var drop_id: String = object.get_metadata(0)["name"]
+	if _tree_has_id(new_parent, drop_id):
+		drop_id = get_unique_id(new_parent, drop_id, object)
+	var drop_path: String = _get_data_path(new_parent).path_join(drop_id)
+	
+	if from_this_tree: # Data moved
+		if object.get_parent() != new_parent:
+			object.get_parent().remove_child(object)
+			new_parent.add_child(object)
+		if drop_id != object.get_metadata(0)["name"]:
+			object.set_text(0, drop_id)
+			object.get_metadata(0)["name"] = drop_id
+		
+		if new_parent.get_child(new_index) != object:
+			if new_index <= -1:
+				object.move_after(new_parent.get_child(-1))
+			elif new_index == 0:
+				object.move_before(new_parent.get_first_child())
+			else:
+				object.move_after(new_parent.get_child(new_index - 1))
+		
+		data_moved.emit(original_path, original_index, drop_path, new_index)
+	else: # Data created
+		data_created.emit(
+				drop_path,
+				new_index,
+				get_data_cell_data(object))
 
 
 func clear_data() -> void:
@@ -230,11 +344,243 @@ func clear_data() -> void:
 	create_item()
 
 
-func add_data(data_id: String, data: Variant, operator: int = OP_EQUAL, on_node: TreeItem = get_root()) -> TreeItem:
+func _get_data_path(item: TreeItem) -> String:
+	if item == null or item == get_root():
+		return ""
+	
+	var path: String = ""
+	
+	var items: Array[String] = []
+	
+	var current_item: TreeItem = item
+	var root: TreeItem = get_root()
+	
+	while current_item != root and current_item != null:
+		items.append(current_item.get_text(0))
+		current_item = current_item.get_parent()
+	
+	items.reverse()
+	
+	return StringUtils.make_path(items)
+
+
+func _get_data_item(path: String) -> TreeItem:
+	var parts: PackedStringArray = path.split("/", false)
+	if parts.is_empty():
+		return get_root()
+	
+	var current_item: TreeItem = get_root()
+	
+	for slice in parts:
+		var found: bool = false
+		for item in current_item.get_children():
+			if item.get_metadata(0)["name"] == slice:
+				found = true
+				current_item = item
+				break
+		if not found:
+			return null
+	
+	return current_item
+
+
+func _do_add_data(data_path: String, data: Variant, operator: int, index: int = -1) -> void:
+	var parts: PackedStringArray = data_path.split("/", false)
+	if parts.is_empty():
+		return
+	var data_id: String = parts[-1]
+	if data_id.is_empty():
+		return
+	
+	var current_item: TreeItem = get_root()
+	for slice in parts.slice(0, -1):
+		var found: bool = false
+		for item in current_item.get_children():
+			if item.get_metadata(0)["name"] == slice:
+				current_item = item
+				found = true
+				break
+		if not found:
+			return
+	
+	if current_item == get_root() or current_item.get_metadata(0)["type"] == ItemType.FOLDER:
+		var can_add: bool = true
+		for item in current_item.get_children():
+			if item.get_metadata(0)["name"] == data_id:
+				can_add = false
+				break
+		if can_add:
+			_add_data_to_tree(data_id, data, operator, current_item)
+
+
+func _do_erase_data(data_path: String) -> void:
+	var target: TreeItem = _get_data_item(data_path)
+	
+	if target == null or target == get_root():
+		return
+	
+	target.free()
+
+
+func _undo_erase_data(data_path: String, data: Variant, operator: int, index: int) -> void:
+	var parts: PackedStringArray = data_path.rsplit("/", false)
+	if parts.is_empty():
+		NFPluginGameHandler._log_msg(
+				"editor - data tree",
+				"Failed to undo data erasure on empty path.",
+				NFPluginGameHandler._LogLevel.WARNING)
+		return
+	
+	var var_id: String = parts[-1]
+	var target: TreeItem = get_root()
+	
+	for path_slice in parts.slice(0, -1):
+		for item in target.get_children():
+			if item.get_metadata(0)["name"] == path_slice:
+				if item.get_metadata(0)["type"] != ItemType.FOLDER:
+					return
+				target = item
+				break
+	
+	for item in target.get_children():
+		if item.get_metadata(0)["name"] == var_id:
+			NFPluginGameHandler._log_msg(
+				"editor - data tree",
+				"Failed to undo data erasure. ID '%s' already used on path '%s'." % [var_id, _get_data_path(item.get_parent())],
+				NFPluginGameHandler._LogLevel.WARNING)
+			return
+	
+	
 	var data_type: int = typeof(data)
+	if data_type == TYPE_DICTIONARY or data_type == TYPE_ARRAY:
+		_add_data_to_tree(var_id, data.duplicate(true), operator, target, index)
+	else:
+		_add_data_to_tree(var_id, data, operator, target, index)
+
+
+func _undo_add_data(data_path: String) -> void:
+	var target: TreeItem = _get_data_item(data_path)
+	
+	if target != null and target != get_root():
+		target.free()
+
+
+func _do_rename_item(path: String, new_name: String) -> void:
+	var item: TreeItem = _get_data_item(path)
+	if item != null and item != get_root():
+		item.set_text(0, new_name)
+		item.get_metadata(0)["name"] = new_name
+
+
+func _data_type_to_internal(type: int) -> int:
+	match type:
+		TYPE_INT, TYPE_FLOAT, TYPE_BOOL, TYPE_STRING:
+			return type
+		_:
+			return TYPE_NIL
+
+
+func _do_update_item_data(path: String, data: Variant) -> void:
+	var item: TreeItem = _get_data_item(path)
+	
+	if item == null or item == get_root() or item.get_metadata(0)["type"] == ItemType.FOLDER:
+		return
+	
+	var new_type: int = _data_type_to_internal(typeof(data))
+	
+	if new_type != item.get_metadata(1):
+		if item.get_metadata(1) == TYPE_DICTIONARY:
+			var btn_idx: int = item.get_button_by_id(1, ButtonIds.TYPE_MENU)
+			if btn_idx != -1:
+				item.erase_button(1, btn_idx)
+		match new_type:
+			TYPE_INT:
+				item.set_icon(0, ICON_INT)
+				item.set_metadata(1, TYPE_INT)
+				item.set_cell_mode(1, TreeItem.CELL_MODE_RANGE)
+				item.set_range_config(1, RANGE_FLOOR, RANGE_CEIL, 1.0)
+				item.set_range(1, data)
+				item.set_editable(1, true)
+			TYPE_FLOAT:
+				item.set_icon(0, ICON_FLOAT)
+				item.set_metadata(1, TYPE_FLOAT)
+				item.set_cell_mode(1, TreeItem.CELL_MODE_RANGE)
+				item.set_range_config(1, RANGE_FLOOR, RANGE_CEIL, RANGE_FLOAT_STEP)
+				item.set_range(1, data)
+				item.set_editable(1, true)
+			TYPE_BOOL:
+				item.set_icon(0, ICON_BOOL)
+				item.set_metadata(1, TYPE_BOOL)
+				item.set_cell_mode(1, TreeItem.CELL_MODE_CHECK)
+				item.set_text(1, "Enabled")
+				item.set_checked(1, data)
+				item.set_editable(1, true)
+			TYPE_STRING:
+				item.set_icon(0, ICON_STRING)
+				item.set_metadata(1, TYPE_STRING)
+				item.set_cell_mode(1, TreeItem.CELL_MODE_STRING)
+				item.set_text(1, data)
+				item.set_editable(1, true)
+			TYPE_DICTIONARY:
+				item.set_icon(0, ICON_FOLDER)
+				item.set_metadata(1, TYPE_DICTIONARY)
+				item.set_selectable(1, false)
+				item.set_editable(0, true)
+				item.set_editable(1, false)
+				item.get_metadata(0)["type"] = ItemType.FOLDER
+				if compact_mode:
+					item.add_button(
+							1,
+							preload("res://addons/nexus_forge/icons/add_variable_icon.svg"),
+							ButtonIds.TYPE_MENU,
+							false,
+							"Add data")
+				else:
+					item.add_button(1, preload("res://addons/nexus_forge/icons/add_int.svg"), ButtonIds.INT, false, "Add Integer")
+					item.add_button(1, preload("res://addons/nexus_forge/icons/add_float.svg"), ButtonIds.FLOAT, false, "Add Float")
+					item.add_button(1, preload("res://addons/nexus_forge/icons/add_bool.svg"), ButtonIds.BOOL, false, "Add Bool")
+					item.add_button(1, preload("res://addons/nexus_forge/icons/add_string.svg"), ButtonIds.STRING, false, "Add String")
+					item.add_button(1, get_theme_icon("FolderCreate", "EditorIcons"), ButtonIds.LEVEL, false, "Add Level")
+				for subdata in data:
+					add_data(subdata, data[subdata], false, item)
+			_:
+				item.set_icon(0, ICON_VARIABLE)
+				item.set_metadata(1, TYPE_NIL)
+				item.get_metadata(0)["data"] = data
+				item.set_cell_mode(1, TreeItem.CELL_MODE_STRING)
+				item.set_text(1, type_string(typeof(data)))
+				item.set_editable(1, false)
+	else:
+		match new_type:
+			TYPE_INT, TYPE_FLOAT:
+				item.set_range(1, data)
+			TYPE_BOOL:
+				item.set_checked(1, data)
+			TYPE_STRING:
+				item.set_text(1, data)
+			_:
+				item.get_metadata(0)["data"] = data
+	
+	item.get_metadata(0)["value"] = data
+
+
+func add_data(data_id: String, data: Variant, operator: int = OP_EQUAL, on_node: TreeItem = get_root()) -> String:
 	var new_name: String = get_unique_id(on_node, data_id)
-	var new_data: TreeItem = on_node.create_child()
-	var metadata: Dictionary = {"name": new_name, "type": ItemType.DATA, "operator": OP_EQUAL}
+	var data_path: String = _get_data_path(on_node).path_join(new_name)
+	
+	var type: int = typeof(data)
+	
+	_add_data_to_tree(new_name, data, operator, on_node)
+	
+	return data_path
+
+
+func _add_data_to_tree(new_name: String, data: Variant, operator: int, on_node: TreeItem = get_root(), index: int = -1) -> TreeItem:
+	var data_type: int = typeof(data)
+	var new_data: TreeItem = on_node.create_child(index)
+	var metadata: Dictionary = {"name": new_name, "type": ItemType.DATA, "value": data}
+	if data_type != TYPE_DICTIONARY:
+		metadata["value"] = data
 	
 	new_data.set_cell_mode(0, TreeItem.CELL_MODE_STRING)
 	new_data.set_text(0, new_name)
@@ -245,14 +591,14 @@ func add_data(data_id: String, data: Variant, operator: int = OP_EQUAL, on_node:
 			new_data.set_icon(0, ICON_INT)
 			new_data.set_metadata(2, TYPE_INT)
 			new_data.set_cell_mode(2, TreeItem.CELL_MODE_RANGE)
-			new_data.set_range_config(2, -RANGE_MAX, RANGE_MAX, 1.0)
+			new_data.set_range_config(2, RANGE_FLOOR, RANGE_CEIL, 1.0)
 			new_data.set_range(2, data)
 			new_data.set_editable(2, true)
 		TYPE_FLOAT:
 			new_data.set_icon(0, ICON_FLOAT)
 			new_data.set_metadata(2, TYPE_FLOAT)
 			new_data.set_cell_mode(2, TreeItem.CELL_MODE_RANGE)
-			new_data.set_range_config(2, -RANGE_MAX, RANGE_MAX, RANGE_FLOAT_STEP)
+			new_data.set_range_config(2, RANGE_FLOOR, RANGE_CEIL, RANGE_FLOAT_STEP)
 			new_data.set_range(2, data)
 			new_data.set_editable(2, true)
 		TYPE_BOOL:
@@ -275,6 +621,7 @@ func add_data(data_id: String, data: Variant, operator: int = OP_EQUAL, on_node:
 			new_data.set_editable(0, true)
 			new_data.set_editable(2, false)
 			metadata["type"] = ItemType.FOLDER
+			new_data.set_metadata(0, metadata)
 			if compact_mode:
 				new_data.add_button(
 						2,
@@ -288,35 +635,252 @@ func add_data(data_id: String, data: Variant, operator: int = OP_EQUAL, on_node:
 				new_data.add_button(2, preload("res://addons/nexus_forge/icons/add_bool.svg"), ButtonIds.BOOL, false, "Add Bool")
 				new_data.add_button(2, preload("res://addons/nexus_forge/icons/add_string.svg"), ButtonIds.STRING, false, "Add String")
 				new_data.add_button(2, get_theme_icon("FolderCreate", "EditorIcons"), ButtonIds.LEVEL, false, "Add Level")
-			for subdata in data.keys():
-				add_data(subdata, data[subdata], OP_EQUAL, new_data)
+			for subdata in data:
+				_add_data_to_tree(subdata, data[subdata], OP_EQUAL, new_data)
 		_:
 			new_data.set_icon(0, ICON_VARIABLE)
 			new_data.set_metadata(2, TYPE_NIL)
-			metadata["data"] = data
 			new_data.set_cell_mode(2, TreeItem.CELL_MODE_STRING)
 			new_data.set_text(2, type_string(data_type))
 			new_data.set_editable(2, false)
 	
+	new_data.add_button(1, TRASH_BIN, ButtonIds.DELETE, false, "Delete Data")
+	
 	if data_type != TYPE_DICTIONARY:
+		new_data.set_metadata(0, metadata)
+		
 		new_data.set_cell_mode(1, TreeItem.CELL_MODE_RANGE)
-		if data_type == TYPE_BOOL or data_type == TYPE_STRING:
-			new_data.set_range_config(1, 0, 1, 1)
-			new_data.set_text(1, "==,!=")
-		else:
+		
+		if data_type == TYPE_INT or data_type == TYPE_FLOAT:
 			new_data.set_range_config(1, 0, 5, 1)
 			new_data.set_text(1, "==,!=,<,<=,>,>=")
+		else:
+			new_data.set_range_config(1, 0, 1, 1)
+			new_data.set_text(1, "==,!=")
 		new_data.set_range(1, operator_to_range(operator))
 		new_data.set_editable(1, true)
 	else:
 		new_data.set_cell_mode(1, TreeItem.CELL_MODE_STRING)
 		new_data.set_editable(1, false)
 	
-	new_data.add_button(2, TRASH_BIN, ButtonIds.DELETE, false, "Delete Data")
-	
-	new_data.set_metadata(0, metadata)
-	
 	return new_data
+
+
+func get_data_cell_data(cell: TreeItem) -> Variant:
+	match cell.get_metadata(1):
+		TYPE_INT:
+			return int(cell.get_range(1))
+		TYPE_FLOAT:
+			return float(cell.get_range(1))
+		TYPE_BOOL:
+			return cell.is_checked(1)
+		TYPE_STRING:
+			return cell.get_text(1)
+		TYPE_DICTIONARY:
+			var subfolder: Dictionary = {}
+			for sub_data in cell.get_children():
+				subfolder[sub_data.get_text(0)] = get_data_cell_data(sub_data)
+			return subfolder
+		TYPE_NIL:
+			var type: int = typeof(cell.get_metadata(0)["data"])
+			if type == TYPE_DICTIONARY or type == TYPE_ARRAY:
+				return cell.get_metadata(0)["data"].duplicate(true)
+			else:
+				return cell.get_metadata(0)["data"]
+		_:
+			return null
+
+
+func _on_button_clicked(item: TreeItem, column: int, id: int, mouse_button_index: int) -> void:
+	var data_path: String = ""
+	var data_copy: Variant = null
+	match id:
+		ButtonIds.DELETE:
+			var path: String = _get_data_path(item)
+			var data: Variant = get_data_cell_data(item)
+			var index: int = item.get_index()
+			
+			item.free()
+			data_erased.emit(path, index, data)
+			return
+		ButtonIds.INT:
+			data_copy = 0
+			data_path = add_data("new_int", 0, false, item)
+		ButtonIds.FLOAT:
+			data_copy = 0.0
+			data_path = add_data("new_float", 0.0, false, item)
+		ButtonIds.BOOL:
+			data_copy = false
+			data_path = add_data("new_bool", false, false, item)
+		ButtonIds.STRING:
+			data_copy = ""
+			data_path = add_data("new_string", "", false, item)
+		ButtonIds.LEVEL:
+			data_copy = {}
+			data_path = add_data("new_folder", {}, false, item)
+		ButtonIds.TYPE_MENU:
+			data_item = item
+			mn.position = DisplayServer.mouse_get_position()
+			mn.popup()
+			return
+	data_created.emit(
+			data_path,
+			-1,
+			data_copy)
+
+
+func on_data_edited() -> void:
+	var edited: TreeItem = get_edited()
+	var path: String = _get_data_path(edited)
+	
+	if get_edited_column() == 1: # Value
+		var from = edited.get_metadata(0)["value"]
+		var to = get_data_cell_data(edited)
+		var emit_update: bool = true
+		
+		match edited.get_metadata(1):
+			TYPE_INT, TYPE_FLOAT:
+				if edited.get_metadata(0)["value"] != int(edited.get_range(1)) if edited.get_metadata(1) == TYPE_INT else edited.get_range(1):
+					edited.get_metadata(0)["value"] = to
+				else:
+					emit_update = false
+			TYPE_BOOL:
+				if edited.get_metadata(0)["value"] != to:
+					edited.get_metadata(0)["value"] = to
+				else:
+					emit_update = false
+			TYPE_STRING:
+				if edited.get_metadata(0)["value"] != to:
+					edited.get_metadata(0)["value"] = to
+				else:
+					emit_update = false
+			TYPE_NIL:
+				if typeof(edited.get_metadata(0)["data"]) == typeof(edited.get_metadata(0)["value"]):
+					if edited.get_metadata(0)["data"] == edited.get_metadata(0)["value"]:
+						emit_update = false
+					else:
+						edited.get_metadata(0)["value"] = to
+		
+		if emit_update:
+			data_updated.emit(
+					path,
+					from,
+					to)
+		return
+	
+	# --- ID updated ---
+	
+	if edited.get_metadata(0)["name"] == edited.get_text(0):
+		return
+	
+	var old_name: String = edited.get_metadata(0)["name"]
+	var new_name: String = get_unique_id(edited.get_parent(), edited.get_text(0), edited)
+	
+	var parent_path: String = _get_data_path(edited.get_parent())
+	var old_path: String = parent_path.path_join(old_name)
+	var new_path: String = parent_path.path_join(new_name)
+	
+	edited.set_text(0, new_name)
+	edited.get_metadata(0)["name"] = new_name
+	
+	data_renamed.emit(
+			parent_path,
+			old_name,
+			new_name)
+
+
+func get_data() -> Dictionary[String, Dictionary]:
+	var result_dict: Dictionary[String, Dictionary] = {}
+	
+	for item in get_root().get_children():
+		_traverse_and_collect(item, result_dict)
+		
+	return result_dict
+
+
+func _traverse_and_collect(item: TreeItem, result_dict: Dictionary) -> void:
+	var meta: Dictionary = item.get_metadata(0)
+	
+	if meta == null or typeof(meta) != TYPE_DICTIONARY or not meta.has("type"):
+		return
+	
+	if meta["type"] == ItemType.DATA:
+		# 1. Get the path using your method
+		var item_path: String = get_path_from(item)
+		
+		# 2. Directly assign the dictionary from your custom getter
+		# This automatically includes both "value" and "operator" keys
+		result_dict[item_path] = get_cell_value(item)
+		
+	elif meta["type"] == ItemType.FOLDER:
+		# Recursively process folder children
+		for child in item.get_children(): # Calling get_children() on a TreeItem returns an Array[TreeItem] with all containing children.
+			_traverse_and_collect(child, result_dict)
+
+
+func get_path_from(item: TreeItem) -> String:
+	var path_items: Array[String] = []
+	
+	var level: TreeItem = item
+	var root: TreeItem = get_root()
+	
+	while level != root and level != null:
+		path_items.append(level.get_text(0))
+		level = level.get_parent()
+	
+	path_items.reverse()
+	
+	if path_items.is_empty():
+		return ""
+	else:
+		return StringUtils.make_path(path_items)
+
+
+func set_data(flat_data: Dictionary[String, Dictionary]) -> void:
+	clear_data()
+	# This dictionary will store our created folder TreeItems.
+	# Key: "folder/path", Value: TreeItem reference
+	var folder_cache: Dictionary = {}
+	
+	var root_node: TreeItem = get_root()
+	
+	for full_path in flat_data.keys():
+		var item_data: Dictionary = flat_data[full_path]
+		
+		var segments: Array[String] = ArrayUtils.create_typed(TYPE_STRING, Array(full_path.split("/")))
+		
+		var item_name: String = segments.pop_back()
+		
+		var current_parent: TreeItem = root_node
+		var running_path: String = ""
+		
+		# 1. Reconstruct the folder hierarchy
+		for segment in segments:
+			# Build the cumulative path to check our cache
+			running_path = running_path.path_join(segment)
+			
+			# If we haven't created this folder yet, make it and cache it
+			if not folder_cache.has(running_path):
+				var new_folder: TreeItem = _add_data_to_tree(segment, {}, OP_EQUAL, current_parent)
+				folder_cache[running_path] = new_folder
+			# Step down into the folder for the next iteration
+			current_parent = folder_cache[running_path]
+		
+		# 2. Add the actual data item
+		# We safely extract the value and operator, providing fallbacks just in case
+		var val: Variant = item_data.get("value")
+		var op: int = item_data.get("operator", OP_EQUAL)
+		
+		add_data(item_name, val, op, current_parent)
+
+
+func search_data(data_text: String) -> void:
+	if current_search == data_text:
+		return
+	var is_empty: bool = data_text.is_empty()
+	for data in get_root().get_children():
+		data.visible = _child_has_data(data, data_text) or is_empty or data.get_text(0).containsn(data_text) or _data_cell_to_string(data).containsn(data_text)
+	current_search = data_text
 
 
 func range_to_operator(range: int) -> int:
@@ -370,146 +934,17 @@ func get_cell_value(cell: TreeItem) -> Dictionary:
 			#for sub_data in cell.get_children():
 				#subfolder[sub_data.get_text(0)] = get_data_cell_data(sub_data)
 			#return subfolder
-		#TYPE_NIL:
-			#return cell.get_metadata(0)["data"]
+		TYPE_NIL:
+			return {"operator": range_to_operator(cell.get_range(1)), "value": cell.get_metadata(0)["value"]}
 		_:
 			return {}
 
 
-func _on_button_clicked(item: TreeItem, column: int, id: int, mouse_button_index: int) -> void:
-	match id:
-		ButtonIds.DELETE:
-			item.free()
-			item_deleted.emit()
-		ButtonIds.INT:
-			add_data("new_int", 0, OP_EQUAL, item)
-		ButtonIds.FLOAT:
-			add_data("new_float", 0.0, OP_EQUAL, item)
-		ButtonIds.BOOL:
-			add_data("new_bool", false, OP_EQUAL, item)
-		ButtonIds.STRING:
-			add_data("new_string", "", OP_EQUAL, item)
-		ButtonIds.LEVEL:
-			add_data("new_folder", {}, OP_EQUAL, item)
-		ButtonIds.TYPE_MENU:
-			data_item = item
-			mn.position = DisplayServer.mouse_get_position()
-			mn.popup()
-			return
-	data_changed.emit()
-
-
-func on_data_edited() -> void:
-	if get_edited_column() != 0:
-		data_changed.emit()
-		return
-	
-	var edited: TreeItem = get_edited()
-	
-	if edited.get_metadata(0)["name"] == edited.get_text(0):
-		return
-	
-	var new_name: String = get_unique_id(edited.get_parent(), edited.get_text(0), edited)
-	
-	edited.set_text(0, new_name)
-	edited.get_metadata(0)["name"] = new_name
-	data_changed.emit()
-
-
-func set_data(flat_data: Dictionary[String, Dictionary]) -> void:
-	clear_data()
-	# This dictionary will store our created folder TreeItems.
-	# Key: "folder/path", Value: TreeItem reference
-	var folder_cache: Dictionary = {}
-	
-	# Assuming get_root() is accessible in this script scope
-	var root_node: TreeItem = get_root()
-	
-	for full_path in flat_data.keys():
-		var item_data: Dictionary = flat_data[full_path]
-		
-		var segments: Array[String] = ArrayUtils.create_typed(TYPE_STRING, Array(full_path.split("/")))
-		
-		var item_name: String = segments.pop_back()
-		
-		var current_parent: TreeItem = root_node
-		var running_path: String = ""
-		
-		# 1. Reconstruct the folder hierarchy
-		for segment in segments:
-			# Build the cumulative path to check our cache
-			running_path = running_path.path_join(segment)
-			
-			# If we haven't created this folder yet, make it and cache it
-			if not folder_cache.has(running_path):
-				# Pass an empty {} to force add_data to just create the folder node
-				var new_folder: TreeItem = add_data(segment, {}, OP_EQUAL, current_parent)
-				folder_cache[running_path] = new_folder
-			# Step down into the folder for the next iteration
-			current_parent = folder_cache[running_path]
-		
-		# 2. Add the actual data item
-		# We safely extract the value and operator, providing fallbacks just in case
-		var val: Variant = item_data.get("value")
-		var op: int = item_data.get("operator", OP_EQUAL)
-		
-		add_data(item_name, val, op, current_parent)
-
-
-func get_data() -> Dictionary[String, Dictionary]:
-	var result_dict: Dictionary[String, Dictionary] = {}
-	
-	for item in get_root().get_children():
-		_traverse_and_collect(item, result_dict)
-		
-	return result_dict
-
-
-func _traverse_and_collect(item: TreeItem, result_dict: Dictionary) -> void:
-	var meta: Dictionary = item.get_metadata(0)
-	
-	if meta == null or typeof(meta) != TYPE_DICTIONARY or not meta.has("type"):
-		return
-	
-	if meta["type"] == ItemType.DATA:
-		# 1. Get the path using your method
-		var item_path: String = get_path_from(item)
-		
-		# 2. Directly assign the dictionary from your custom getter
-		# This automatically includes both "value" and "operator" keys
-		result_dict[item_path] = get_cell_value(item)
-		
-	elif meta["type"] == ItemType.FOLDER:
-		# Recursively process folder children
-		for child in item.get_children(): # Calling get_children() on a TreeItem returns an Array[TreeItem] with all containing children.
-			_traverse_and_collect(child, result_dict)
-
-
-func get_path_from(item: TreeItem) -> String:
-	var path_items: Array[String] = []
-	
-	var level: TreeItem = item
-	var root: TreeItem = get_root()
-	
-	while level != root and level != null:
-		path_items.append(level.get_text(0))
-		level = level.get_parent()
-	
-	path_items.reverse()
-	
-	if path_items.is_empty():
-		return ""
-	else:
-		return StringUtils.make_path(path_items)
-
-
-func search_data(data_text: String) -> void:
-	if current_search == data_text:
-		return
-	var is_empty: bool = data_text.is_empty()
-	for data in get_root().get_children():
-		data.visible = _child_has_data(data, data_text) or is_empty or data.get_text(0).containsn(data_text) or _data_cell_to_string(data).containsn(data_text)
-	current_search = data_text
+func _tree_has_id(item: TreeItem, id: String) -> bool:
+	for tree in item.get_children():
+		if tree.get_metadata(0)["name"] == id:
+			return true
+	return false
 
 
 func _child_has_data(item: TreeItem, text: String) -> bool:
@@ -532,4 +967,3 @@ func _data_cell_to_string(item: TreeItem) -> String:
 			return "true" if item.is_checked(1) else "false"
 		_:
 			return ""
-	

--- a/addons/nexus_forge/quests/obj_req_tree_script.gd
+++ b/addons/nexus_forge/quests/obj_req_tree_script.gd
@@ -69,7 +69,7 @@ func ready_plugin() -> void:
 	set_column_expand_ratio(0, 2)
 	set_column_expand_ratio(2, 3)
 	
-	set_column_custom_minimum_width(1, 60)
+	set_column_custom_minimum_width(1, 80)
 	
 	item_edited.connect(on_data_edited)
 	

--- a/addons/nexus_forge/quests/quest_files_tree.gd
+++ b/addons/nexus_forge/quests/quest_files_tree.gd
@@ -2,26 +2,23 @@
 extends Tree
 
 
-signal quest_selected(quest: Quest)
-signal quest_close_pressed(quest: Quest, requires_save: bool, structure: Array[Dictionary])
-
-
-var _active: TreeItem = null
+signal quest_selected(quest_id: int)
+signal quest_close_pressed(quest_id: int, requires_save: bool, structure: Array[Dictionary])
 
 
 func ready_plugin() -> void:
 	create_item()
 	
-	item_selected.connect(_on_item_selected, CONNECT_DEFERRED)
+	item_mouse_selected.connect(_on_item_mouse_selected)
 	button_clicked.connect(_on_button_clicked)
 
 
-func add_quest(quest: Quest, select: bool = false, emit_select: bool = true) -> void:
+func add_quest(quest_id: int, resource_path: String, select: bool = false, emit_select: bool = true) -> void:
 	var quest_item: TreeItem = get_root().create_child()
 	
-	quest_item.set_text(0, quest.resource_path.get_file().get_basename())
-	quest_item.set_tooltip_text(0, quest.resource_path)
-	quest_item.set_metadata(0, {"resource": quest, "save_required": false, "structure": ArrayUtils.create_typed(TYPE_DICTIONARY)})
+	quest_item.set_text(0, resource_path.get_file().get_basename())
+	quest_item.set_tooltip_text(0, resource_path)
+	quest_item.set_metadata(0, {"id": quest_id, "path": resource_path, "save_required": false, "structure": ArrayUtils.create_typed(TYPE_DICTIONARY)})
 	
 	quest_item.add_button(
 			0,
@@ -31,30 +28,27 @@ func add_quest(quest: Quest, select: bool = false, emit_select: bool = true) -> 
 			"Close quest")
 	
 	if select:
-		_active = quest_item
+		quest_item.select(0)
 		if emit_select:
-			quest_item.select(0)
-		else:
-			item_selected.disconnect(_on_item_selected)
-			quest_item.select(0)
-			item_selected.connect(_on_item_selected, CONNECT_DEFERRED)
+			quest_selected.emit(quest_id)
 
 
 func set_current_save_required(set_required: bool) -> void:
-	if _active == null or _active.get_metadata(0)["save_required"] == set_required:
+	var active_file: TreeItem = get_selected()
+	if active_file == null or active_file.get_metadata(0)["save_required"] == set_required:
 		return
 	
 	if set_required:
-		_active.set_text(0, _active.get_text(0) + "*")
+		active_file.set_text(0, active_file.get_text(0) + "*")
 	else:
-		_active.set_text(0, _active.get_text(0).trim_suffix("*"))
+		active_file.set_text(0, active_file.get_text(0).trim_suffix("*"))
 	
-	_active.get_metadata(0)["save_required"] = set_required
+	active_file.get_metadata(0)["save_required"] = set_required
 
 
-func set_save_required(on_quest: Quest, required: bool) -> void:
+func set_save_required(on_quest: int, required: bool) -> void:
 	for item in get_root().get_children():
-		if item.get_metadata(0)["resource"] == on_quest:
+		if item.get_metadata(0)["id"] == on_quest:
 			if item.get_metadata(0)["save_required"] == required:
 				return
 			if required:
@@ -66,6 +60,13 @@ func set_save_required(on_quest: Quest, required: bool) -> void:
 			return
 
 
+func update_path_on(on_quest: int, new_path: String) -> void:
+	for item in get_root().get_children():
+		if item.get_metadata(0)["id"] == on_quest:
+			item.set_tooltip_text(0, new_path)
+			item.get_metadata(0)["path"] = new_path
+
+
 func set_all_saved() -> void:
 	for item in get_root().get_children():
 		if item.get_metadata(0)["save_required"]:
@@ -73,59 +74,34 @@ func set_all_saved() -> void:
 			item.get_metadata(0)["save_required"] = false
 
 
-func has_quest(quest: Quest) -> bool:
+func has_quest(quest_id: int) -> bool:
 	for item in get_root().get_children():
-		if item.get_metadata(0)["resource"] == quest:
+		if item.get_metadata(0)["id"] == quest_id:
 			return true
 	return false
 
 
-func close_quest(quest: Quest) -> void:
+func remove_quest(quest_id: int) -> void:
 	for item in get_root().get_children():
-		if item.get_metadata(0)["resource"] == quest:
-			if _active == item:
-				_active = null
+		if item.get_metadata(0)["id"] == quest_id:
 			item.free()
 			return
 
 
 func close_with_path(path: String) -> void:
 	for item in get_root().get_children():
-		if item.get_metadata(0)["resource"].resource_path == path:
-			if _active == item:
-				_active = null
+		if item.get_metadata(0)["path"] == path:
 			item.free()
 			return
 
 
-func select_quest(quest: Quest, emit_select: bool = true) -> void:
+func select_quest(quest_id: int, emit_select: bool = true) -> void:
 	for item in get_root().get_children():
-		if item.get_metadata(0)["resource"] == quest:
-			if _active == item:
-				return
-			_active = item
+		if item.get_metadata(0)["id"] == quest_id:
+			item.select(0)
 			if emit_select:
-				item.select(0)
-			else:
-				item_selected.disconnect(_on_item_selected)
-				item.select(0)
-				item_selected.connect(_on_item_selected, CONNECT_DEFERRED)
+				quest_selected.emit(quest_id)
 			return
-
-
-func get_open_quest_paths() -> Array[String]:
-	var paths: Array[String] = []
-	
-	if get_root() == null:
-		return paths
-	
-	for item in get_root().get_children():
-		var path: String = item.get_metadata(0)["resource"].resource_path
-		if path.is_empty():
-			continue
-		paths.append(path)
-	
-	return paths
 
 
 func has_unsaved_files() -> bool:
@@ -140,27 +116,30 @@ func get_unsaved_files() -> Array[Dictionary]:
 	for item in get_root().get_children():
 		if item.get_metadata(0)["save_required"]:
 			var metadata: Dictionary = item.get_metadata(0)
-			files.append({"resource": metadata["resource"], "structure": metadata["structure"]})
+			files.append({"id": metadata["id"], "structure": metadata["structure"]})
 	return files
 
 
 func search_for(text: String) -> void:
 	var empty: bool = text.is_empty()
 	for item in get_root().get_children():
-		item.visible = empty or item.get_metadata(0)["resource"].resource_path.containsn(text)
+		item.visible = empty or item.get_metadata(0)["path"].containsn(text)
 
 
-func set_quest_structure(on_quest: Quest, structure: Array[Dictionary]) -> void:
+func set_quest_structure(quest_id: int, structure: Array[Dictionary]) -> void:
 	for item in get_root().get_children():
 		var metadata: Dictionary = item.get_metadata(0)
-		if metadata["resource"] == on_quest:
+		if metadata["id"] == quest_id:
 			metadata["structure"].assign(structure)
 			return
 
 
-func _on_item_selected() -> void:
-	_active = get_selected()
-	quest_selected.emit(_active.get_metadata(0)["resource"], _active.get_metadata(0)["structure"])
+func _on_item_mouse_selected(mouse_position: Vector2, mouse_button_index: int) -> void:
+	if mouse_button_index != MOUSE_BUTTON_LEFT:
+		return
+	var selected: TreeItem = get_selected()
+	
+	quest_selected.emit(selected.get_metadata(0)["id"], selected.get_metadata(0)["structure"])
 
 
 func _on_button_clicked(item: TreeItem, _column: int, id: int, mouse_button_index: int) -> void:
@@ -168,4 +147,4 @@ func _on_button_clicked(item: TreeItem, _column: int, id: int, mouse_button_inde
 		return
 	
 	if id == 0:
-		quest_close_pressed.emit(item.get_metadata(0)["resource"], item.get_metadata(0)["save_required"], item.get_metadata(0)["structure"])
+		quest_close_pressed.emit(item.get_metadata(0)["id"], item.get_metadata(0)["save_required"], item.get_metadata(0)["structure"])

--- a/addons/nexus_forge/quests/quest_files_tree.gd
+++ b/addons/nexus_forge/quests/quest_files_tree.gd
@@ -3,7 +3,7 @@ extends Tree
 
 
 signal quest_selected(quest_id: int)
-signal quest_close_pressed(quest_id: int, requires_save: bool, structure: Array[Dictionary])
+signal quest_close_pressed(quest_id: int, requires_save: bool)
 
 
 func ready_plugin() -> void:
@@ -140,20 +140,12 @@ func search_for(text: String) -> void:
 		item.visible = empty or item.get_metadata(0)["path"].containsn(text)
 
 
-func set_quest_structure(quest_id: int, structure: Array[Dictionary]) -> void:
-	for item in get_root().get_children():
-		var metadata: Dictionary = item.get_metadata(0)
-		if metadata["id"] == quest_id:
-			metadata["structure"].assign(structure)
-			return
-
-
 func _on_item_mouse_selected(mouse_position: Vector2, mouse_button_index: int) -> void:
 	if mouse_button_index != MOUSE_BUTTON_LEFT:
 		return
 	var selected: TreeItem = get_selected()
 	
-	quest_selected.emit(selected.get_metadata(0)["id"], selected.get_metadata(0)["structure"])
+	quest_selected.emit(selected.get_metadata(0)["id"])
 
 
 func _on_button_clicked(item: TreeItem, _column: int, id: int, mouse_button_index: int) -> void:
@@ -161,4 +153,7 @@ func _on_button_clicked(item: TreeItem, _column: int, id: int, mouse_button_inde
 		return
 	
 	if id == 0:
-		quest_close_pressed.emit(item.get_metadata(0)["id"], item.get_metadata(0)["save_required"], item.get_metadata(0)["structure"])
+		var metadata: Dictionary = item.get_metadata(0)
+		quest_close_pressed.emit(
+				metadata["id"],
+				metadata["save_required"])

--- a/addons/nexus_forge/quests/quest_files_tree.gd
+++ b/addons/nexus_forge/quests/quest_files_tree.gd
@@ -46,6 +46,13 @@ func set_current_save_required(set_required: bool) -> void:
 	active_file.get_metadata(0)["save_required"] = set_required
 
 
+func update_quest_id(old_id: int, new_id: int) -> void:
+	for item in get_root().get_children():
+			if item.get_metadata(0)["id"] == old_id:
+				item.get_metadata(0)["id"] = new_id
+				return
+
+
 func set_save_required(on_quest: int, required: bool) -> void:
 	for item in get_root().get_children():
 		if item.get_metadata(0)["id"] == on_quest:
@@ -74,9 +81,16 @@ func set_all_saved() -> void:
 			item.get_metadata(0)["save_required"] = false
 
 
-func has_quest(quest_id: int) -> bool:
+func has_quest_id(quest_id: int) -> bool:
 	for item in get_root().get_children():
 		if item.get_metadata(0)["id"] == quest_id:
+			return true
+	return false
+
+
+func has_quest_file(quest_path: String) -> bool:
+	for item in get_root().get_children():
+		if item.get_metadata(0)["path"] == quest_path:
 			return true
 	return false
 

--- a/addons/nexus_forge/quests/quest_hierarchy_tree.gd
+++ b/addons/nexus_forge/quests/quest_hierarchy_tree.gd
@@ -20,7 +20,7 @@ signal objective_duplicated(from_stage: StringName, objective: StringName, dupli
 
 signal stage_moved(stage_id: StringName, from_index: int, to_index: int)
 signal objective_moved(objective_id: StringName, from_stage: StringName, from_index: int, to_stage: StringName, to_index: int)
-signal stage_erased(stage_id: StringName, index: int)
+signal stage_erased(stage_id: StringName, index: int, objectives: Array[String])
 signal objective_erased(from_stage: StringName, objective_id: StringName, index: int)
 
 
@@ -209,7 +209,7 @@ func move_objective(objective_id: StringName, from_stage: StringName, to_stage: 
 				NFPluginGameHandler._LogLevel.ERROR)
 		return
 	
-	var target_index: int = wrapi(to_index, 0, max_index)
+	var target_index: int = wrapi(to_index, 0, child_count)
 	var current_index: int = origin.get_index()
 	
 	if current_index != target_index:
@@ -237,7 +237,7 @@ func move_stage(stage_id: StringName, to_index: int) -> void:
 				NFPluginGameHandler._LogLevel.ERROR)
 		return
 	
-	var target_index: int = wrapi(to_index, 0, max_index)
+	var target_index: int = wrapi(to_index, 0, child_count)
 	var current_index: int = stage.get_index()
 	
 	if current_index == target_index:
@@ -356,7 +356,7 @@ func add_stage(stage_id: String, index: int = -1) -> TreeItem:
 		var child_count: int = root.get_child_count()
 		var max_index: int = child_count - 1
 		if RangeUtils.is_between(index, -child_count, max_index):
-			var target_index: int = wrapi(index, 0, max_index)
+			var target_index: int = wrapi(index, 0, child_count)
 			var current_index: int = stage_item.get_index()
 			if current_index != target_index:
 				if target_index == 0:
@@ -390,6 +390,16 @@ func add_objective(on_stage: StringName, objective_id: StringName, index: int = 
 	add_objective_on_tree(stage, objective_id, index)
 
 
+func _restore_objectives(on_stage: StringName, objectives: Array[String]) -> void:
+	var stage: TreeItem = get_stage(on_stage)
+	
+	if stage == null:
+		return
+	
+	for objective in objectives:
+		add_objective_on_tree(stage, objective)
+
+
 func add_objective_on_tree(on_item: TreeItem, objective_id: String, index: int = -1) -> void:
 	var objective_item: TreeItem = on_item.create_child()
 	objective_item.set_text(0, objective_id)
@@ -404,7 +414,7 @@ func add_objective_on_tree(on_item: TreeItem, objective_id: String, index: int =
 	var max_index: int = child_count - 1
 	if not RangeUtils.is_between(index, -child_count, max_index):
 		return
-	var target_index: int = wrapi(index, 0, max_index)
+	var target_index: int = wrapi(index, 0, child_count)
 	var current_index: int = objective_item.get_index()
 	if target_index == current_index:
 		return
@@ -676,8 +686,12 @@ func _on_popup_id_pressed(id: int) -> void:
 		PopupItemID.REMOVE_ITEM:
 			match target.get_metadata(0)["type"]:
 				ItemType.STAGE:
+					var objectives: Array[String] = []
+					for objective in target.get_children():
+						objectives.append(objective.get_text(0))
 					stage_erased.emit(target.get_metadata(0)["id"],
-					target.get_index())
+					target.get_index(),
+					objectives)
 					target.free()
 				ItemType.OBJECTIVE:
 					objective_erased.emit(target.get_parent().get_metadata(0)["id"],

--- a/addons/nexus_forge/quests/quest_hierarchy_tree.gd
+++ b/addons/nexus_forge/quests/quest_hierarchy_tree.gd
@@ -13,17 +13,15 @@ signal quest_id_changed(from: StringName, to: StringName)
 signal stage_id_changed(from: StringName, to: StringName)
 signal objective_id_changed(on_stage: StringName, from: StringName, to: StringName)
 
-signal objective_rearranged(from_stage: StringName, to_stage: StringName, objective_id: StringName)
-
-signal stage_erased(stage_id: StringName)
-signal objective_erased(from_stage: StringName, objective_id: StringName)
-
 signal entry_stage_selected(stage_id: StringName)
 
 signal stage_duplicated(from: StringName, duplicate_id: StringName)
 signal objective_duplicated(from_stage: StringName, objective: StringName, duplicate_id: StringName)
 
-signal tree_changed
+signal stage_moved(stage_id: StringName, from_index: int, to_index: int)
+signal objective_moved(objective_id: StringName, from_stage: StringName, from_index: int, to_stage: StringName, to_index: int)
+signal stage_erased(stage_id: StringName, index: int)
+signal objective_erased(from_stage: StringName, objective_id: StringName, index: int)
 
 
 enum ItemType {
@@ -77,7 +75,7 @@ func _get_drag_data(at_position: Vector2) -> Variant:
 	preview.text = "   " + item.get_text(0)
 	set_drag_preview(preview)
 	
-	return {"type": "quest_item", "item": item}#, "origin_stage": item.get_parent().get_metadata(0)["id"]}
+	return {"type": "quest_item", "item": item}
 
 
 func _can_drop_data(at_position: Vector2, data: Variant) -> bool:
@@ -118,41 +116,159 @@ func _can_drop_data(at_position: Vector2, data: Variant) -> bool:
 func _drop_data(at_position: Vector2, data: Variant) -> void:
 	var on_item: TreeItem = get_item_at_position(at_position)
 	var section: int = get_drop_section_at_position(at_position)
-	var item_count: int = 0# data["item"].get_parent().get_child_count()
+	var item: TreeItem = data["item"]
+	
+	var original_parent: TreeItem = item.get_parent()
+	var original_index: int = item.get_index()
+	var item_type: int = item.get_metadata(0)["type"]
+	var item_id: StringName = item.get_metadata(0)["id"]
+	var origin_stage_id: StringName = &""
+	
+	if item_type == ItemType.OBJECTIVE:
+		origin_stage_id = original_parent.get_metadata(0)["id"]
+	
 	if on_item.get_metadata(0)["type"] == ItemType.QUEST:
-		item_count = root.get_child_count()
-		if 1 < item_count and data["item"].get_index() < item_count - 1:
-			data["item"].move_after(root.get_child(item_count - 1))
-			tree_changed.emit()
-	elif on_item.get_metadata(0)["type"] == ItemType.STAGE:
-		if section == 0: # on
-			var is_changed: bool = data["item"].get_parent() != on_item
-			var origin_stage: String = data["item"].get_parent().get_metadata(0)["id"]
-			data["item"].get_parent().remove_child(data["item"])
-			on_item.add_child(data["item"])
-			if is_changed:
-				objective_rearranged.emit(origin_stage, on_item.get_metadata(0)["id"], data["item"].get_metadata(0)["id"])
+		var item_count: int = root.get_child_count()
+		if 1 < item_count and item.get_index() < item_count - 1:
+			item.move_after(root.get_child(item_count - 1))
+	elif on_item.get_metadata(0)["type"] == ItemType.STAGE: # Moving an objective
+		if section == 0: # Dropped ON a stage (Objective reassignment)
+			original_parent.remove_child(item)
+			on_item.add_child(item)
 		elif section == -1: # Above
-			data["item"].move_before(on_item)
-			tree_changed.emit()
+			item.move_before(on_item)
 		elif section == 1: # Below
-			data["item"].move_after(on_item)
-			tree_changed.emit()
+			item.move_after(on_item)
 	else:
 		if section == 1:
-			data["item"].move_after(on_item)
+			item.move_after(on_item)
 		else:
-			data["item"].move_before(on_item)
-		tree_changed.emit()
-		
-		
-		#var target: TreeItem = on_item.get_parent()
-		#data["item"].get_parent().remove_child(data["item"])
-		#target.add_child(data["item"])
-		#target_stage = target.get_metadata(0)["id"]
-	#sort_single_item(data["item"])
-	#
-	#objective_rearranged.emit(data["origin_stage"], target_stage, data["item"].get_metadata(0)["id"])
+			item.move_before(on_item)
+	
+	var new_parent: TreeItem = item.get_parent()
+	var new_index: int = item.get_index()
+	
+	if item_type == ItemType.STAGE:
+		if original_index != new_index:
+			stage_moved.emit(item_id, original_index, new_index)
+	elif item_type == ItemType.OBJECTIVE:
+		var new_stage_id: StringName = new_parent.get_metadata(0)["id"]
+		if origin_stage_id != new_stage_id or original_index != new_index:
+			objective_moved.emit(item_id, origin_stage_id, original_index, new_stage_id, new_index)
+
+
+func erase_stage(stage_id: StringName) -> void:
+	var stage: TreeItem = get_stage(stage_id)
+	if stage != null:
+		stage.free()
+
+
+func erase_objective(on_stage: StringName, objective_id: StringName) -> void:
+	var objective: TreeItem = get_objective(on_stage, objective_id)
+	if objective != null:
+		objective.free()
+
+
+func get_stage(stage_id: StringName) -> TreeItem:
+	for item in get_root().get_children():
+		if item.get_metadata(0)["id"] == stage_id:
+			return item
+	return null
+
+
+func get_objective(from_stage: StringName, objective_id: StringName) -> TreeItem:
+	var stage: TreeItem = get_stage(from_stage)
+	
+	if stage == null:
+		return null
+	
+	for objective in stage.get_children():
+		if objective.get_metadata(0)["id"] == objective_id:
+			return objective
+	return null
+
+
+func move_objective(objective_id: StringName, from_stage: StringName, to_stage: StringName, to_index: int) -> void:
+	var target: TreeItem = get_stage(to_stage)
+	var origin: TreeItem = get_objective(from_stage, objective_id)
+	
+	if origin == null or target == null or has_id(origin.get_text(0), target, origin):
+		return
+	
+	if target != origin.get_parent():
+		origin.get_parent().remove_child(origin)
+		target.add_child(origin)
+	
+	var child_count: int = target.get_child_count()
+	var max_index: int = child_count - 1
+	
+	if to_index < -child_count or max_index < to_index:
+		NFPluginGameHandler._log_msg(
+				"odyssey - editor",
+				"Failed changing objective '%s' index. Index out of bounds" % objective_id,
+				NFPluginGameHandler._LogLevel.ERROR)
+		return
+	
+	var target_index: int = wrapi(to_index, 0, max_index)
+	var current_index: int = origin.get_index()
+	
+	if current_index != target_index:
+		if target_index == 0:
+			origin.move_before(target.get_first_child())
+		else:
+			if target_index < current_index:
+				target_index -= 1
+			origin.move_after(target.get_child(target_index))
+
+
+func move_stage(stage_id: StringName, to_index: int) -> void:
+	var stage: TreeItem = get_stage(stage_id)
+	
+	if stage == null:
+		return
+	
+	var child_count: int = get_root().get_child_count()
+	var max_index: int = child_count - 1
+	
+	if to_index < -child_count or max_index < to_index:
+		NFPluginGameHandler._log_msg(
+				"odyssey - editor",
+				"Failed changing stage '%s' index. Index out of bounds",
+				NFPluginGameHandler._LogLevel.ERROR)
+		return
+	
+	var target_index: int = wrapi(to_index, 0, max_index)
+	var current_index: int = stage.get_index()
+	
+	if current_index == target_index:
+		return
+	
+	if target_index == 0:
+		stage.move_before(get_root().get_first_child())
+	else:
+		if target_index < current_index:
+			target_index -= 1
+		stage.move_after(get_root().get_child(target_index))
+
+
+func set_objective_id(on_stage: StringName, from: StringName, to: StringName) -> void:
+	var objective: TreeItem = get_objective(on_stage, from)
+	var str_id: String = String(to)
+	
+	if objective == null or has_id(to, objective.get_parent(), objective):
+		return
+	
+	objective.set_text(0, String(to))
+	objective.get_metadata(0)["id"] = to
+
+
+func set_stage_id(from: StringName, to: StringName) -> void:
+	var stage: TreeItem = get_stage(from)
+	var target_id: String = String(to)
+	if stage == null or has_id(target_id, get_root(), stage):
+		return
+	stage.set_text(0, target_id)
+	stage.get_metadata(0)["id"] = to
 
 
 func get_entry_stage() -> StringName:
@@ -189,11 +305,11 @@ func set_quest(quest: Quest, select: bool = false, emit_select: bool = true) -> 
 	root.disable_folding = true
 	root.set_icon(0, preload("res://addons/nexus_forge/icons/scroll_full.svg"))
 	root.add_button(
-			0,
-			get_theme_icon("Add", "EditorIcons"),
-			ButtonID.ADD_STAGE,
-			false,
-			"Create stage")
+		0,
+		get_theme_icon("Add", "EditorIcons"),
+		ButtonID.ADD_STAGE,
+		false,
+		"Create stage")
 	root.set_metadata(0, {"id": quest.id, "type": ItemType.QUEST})
 	
 	for stage_id in quest.stages():
@@ -202,11 +318,11 @@ func set_quest(quest: Quest, select: bool = false, emit_select: bool = true) -> 
 		stage_item.set_editable(0, true)
 		stage_item.set_icon(0, preload("res://addons/nexus_forge/icons/sign_icon.svg"))
 		stage_item.add_button(
-				0,
-				get_theme_icon("Add", "EditorIcons"),
-				ButtonID.ADD_OBJECTIVE,
-				false,
-				"Create objective")
+			0,
+			get_theme_icon("Add", "EditorIcons"),
+			ButtonID.ADD_OBJECTIVE,
+			false,
+			"Create objective")
 		stage_item.set_metadata(0, {"id": stage_id, "type": ItemType.STAGE, "is_entry": quest.entry_stage == stage_id})
 		if quest.entry_stage == stage_id:
 			stage_item.set_icon_modulate(0, ENTRY_COLOR)
@@ -223,18 +339,32 @@ func set_quest(quest: Quest, select: bool = false, emit_select: bool = true) -> 
 			quest_selected.emit()
 
 
-func add_stage(stage_id: String) -> TreeItem:
+func add_stage(stage_id: String, index: int = -1) -> TreeItem:
 	var stage_item: TreeItem = root.create_child()
 	stage_item.set_text(0, stage_id)
 	stage_item.set_editable(0, true)
 	stage_item.set_icon(0, preload("res://addons/nexus_forge/icons/sign_icon.svg"))
 	stage_item.add_button(
-			0,
-			get_theme_icon("Add", "EditorIcons"),
-			ButtonID.ADD_OBJECTIVE,
-			false,
-			"Create objective")
+		0,
+		get_theme_icon("Add", "EditorIcons"),
+		ButtonID.ADD_OBJECTIVE,
+		false,
+		"Create objective")
 	stage_item.set_metadata(0, {"id": StringName(stage_id), "type": ItemType.STAGE, "is_entry": false})
+	
+	if index != -1:
+		var child_count: int = root.get_child_count()
+		var max_index: int = child_count - 1
+		if RangeUtils.is_between(index, -child_count, max_index):
+			var target_index: int = wrapi(index, 0, max_index)
+			var current_index: int = stage_item.get_index()
+			if current_index != target_index:
+				if target_index == 0:
+					stage_item.move_before(root.get_first_child())
+				else:
+					if target_index < current_index:
+						target_index -= 1
+					stage_item.move_after(root.get_child(target_index))
 	
 	return stage_item
 
@@ -251,12 +381,39 @@ func select_stage(stage_id: StringName, emit_select: bool = true) -> void:
 			return
 
 
-func add_objective(on_item: TreeItem, objective_id: String) -> void:
+func add_objective(on_stage: StringName, objective_id: StringName, index: int = -1) -> void:
+	var stage: TreeItem = get_stage(on_stage)
+	
+	if stage == null or has_id(objective_id, stage):
+		return
+	
+	add_objective_on_tree(stage, objective_id, index)
+
+
+func add_objective_on_tree(on_item: TreeItem, objective_id: String, index: int = -1) -> void:
 	var objective_item: TreeItem = on_item.create_child()
 	objective_item.set_text(0, objective_id)
 	objective_item.set_editable(0, true)
 	objective_item.set_icon(0, preload("res://addons/nexus_forge/icons/target_icon.svg"))
 	objective_item.set_metadata(0, {"id": StringName(objective_id), "type": ItemType.OBJECTIVE})
+	
+	if index == -1:
+		return
+	
+	var child_count: int = on_item.get_child_count()
+	var max_index: int = child_count - 1
+	if not RangeUtils.is_between(index, -child_count, max_index):
+		return
+	var target_index: int = wrapi(index, 0, max_index)
+	var current_index: int = objective_item.get_index()
+	if target_index == current_index:
+		return
+	if target_index == 0:
+		objective_item.move_before(on_item.get_first_child())
+	else:
+		if target_index < current_index:
+			target_index -= 1
+		objective_item.move_after(on_item.get_child(target_index))
 
 
 func sort_all() -> void:
@@ -422,7 +579,6 @@ func _on_button_clicked(item: TreeItem, _column: int, id: int, mouse_button_inde
 			dialog.use_blacklist = true
 			dialog.title = "Create stage"
 			dialog.line_placeholder_text = "Stage ID"
-			#dialog.character_blacklist.append(" ")
 			for stage in item.get_children():
 				dialog.text_blacklist.append(stage.get_text(0))
 			add_child(dialog)
@@ -436,7 +592,6 @@ func _on_button_clicked(item: TreeItem, _column: int, id: int, mouse_button_inde
 				stage_created.emit(StringName(result[1]))
 			
 			dialog.queue_free()
-			
 		ButtonID.ADD_OBJECTIVE:
 			var dialog := preload("res://addons/nexus_forge/dialogs/lineedit_confirmation_dialog.gd").new()
 			dialog.allow_empty = false
@@ -453,7 +608,7 @@ func _on_button_clicked(item: TreeItem, _column: int, id: int, mouse_button_inde
 			var result: Array = await dialog.dialog_finished
 			
 			if result[0]:
-				add_objective(item, result[1])
+				add_objective_on_tree(item, result[1])
 				objective_created.emit(item.get_metadata(0)["id"], StringName(result[1]))
 			
 			dialog.queue_free()
@@ -494,11 +649,11 @@ func _on_item_clicked(mouse_position: Vector2, mouse_button_index: int) -> void:
 		quest_popup.get_item_index(PopupItemID.ADD_ITEM),
 		selected.get_metadata(0)["type"] == ItemType.OBJECTIVE)
 	quest_popup.set_item_disabled(
-			quest_popup.get_item_index(PopupItemID.SET_ENTRY),
-			selected.get_metadata(0)["type"] != ItemType.STAGE)
+		quest_popup.get_item_index(PopupItemID.SET_ENTRY),
+		selected.get_metadata(0)["type"] != ItemType.STAGE)
 	quest_popup.set_item_disabled(
-			quest_popup.get_item_index(PopupItemID.DUPLICATE),
-			selected.get_metadata(0)["type"] == ItemType.QUEST)
+		quest_popup.get_item_index(PopupItemID.DUPLICATE),
+		selected.get_metadata(0)["type"] == ItemType.QUEST)
 	
 	quest_popup.popup()
 
@@ -521,10 +676,13 @@ func _on_popup_id_pressed(id: int) -> void:
 		PopupItemID.REMOVE_ITEM:
 			match target.get_metadata(0)["type"]:
 				ItemType.STAGE:
-					stage_erased.emit(target.get_metadata(0)["id"])
+					stage_erased.emit(target.get_metadata(0)["id"],
+					target.get_index())
 					target.free()
 				ItemType.OBJECTIVE:
-					objective_erased.emit(target.get_parent().get_metadata(0)["id"], target.get_metadata(0)["id"])
+					objective_erased.emit(target.get_parent().get_metadata(0)["id"],
+					target.get_metadata(0)["id"],
+					target.get_index())
 					target.free()
 		PopupItemID.SET_ENTRY:
 			if not target.get_metadata(0)["is_entry"]:
@@ -552,10 +710,10 @@ func _on_popup_id_pressed(id: int) -> void:
 				if type == ItemType.STAGE:
 					var dupe_stage: TreeItem = add_stage(result[1])
 					for obj in target.get_children():
-						add_objective(dupe_stage, obj.get_text(0))
+						add_objective_on_tree(dupe_stage, obj.get_text(0))
 					stage_duplicated.emit(target.get_metadata(0)["id"], StringName(result[1]))
 				else:
-					add_objective(target.get_parent(), result[1])
+					add_objective_on_tree(target.get_parent(), result[1])
 					objective_duplicated.emit(target.get_parent().get_metadata(0)["id"], target.get_metadata(0)["id"], StringName(result[1]))
 				
 			dialog.queue_free()

--- a/addons/nexus_forge/quests/quest_hierarchy_tree.gd
+++ b/addons/nexus_forge/quests/quest_hierarchy_tree.gd
@@ -2,7 +2,7 @@
 extends Tree
 
 
-signal quest_selected(quest: StringName)
+signal quest_selected
 signal stage_selected(stage: StringName)
 signal objective_selected(of_stage: StringName, objective: StringName)
 
@@ -63,7 +63,7 @@ func ready_plugin() -> void:
 	quest_popup.add_item("Set as entry", PopupItemID.SET_ENTRY)
 	quest_popup.id_pressed.connect(_on_popup_id_pressed)
 	
-	item_mouse_selected.connect(_on_item_clicked, CONNECT_DEFERRED)
+	item_mouse_selected.connect(_on_item_clicked)
 	button_clicked.connect(_on_button_clicked)
 	item_edited.connect(_on_item_edited)
 
@@ -221,12 +221,9 @@ func set_quest(quest: Quest, select: bool = false, emit_select: bool = true) -> 
 			objective_item.set_metadata(0, {"id": objective_id, "type": ItemType.OBJECTIVE})
 	
 	if select:
+		root.select(0)
 		if emit_select:
-			root.select(0)
-		else:
-			item_mouse_selected.disconnect(_on_item_clicked)
-			root.select(0)
-			item_mouse_selected.connect(_on_item_clicked, CONNECT_DEFERRED)
+			quest_selected.emit()
 
 
 func add_stage(stage_id: String) -> TreeItem:
@@ -266,6 +263,9 @@ func add_objective(on_item: TreeItem, objective_id: String) -> void:
 
 
 func sort_all() -> void:
+	if root == null:
+		return
+	
 	var stages: Array[TreeItem] = root.get_children()
 	var stage_count: int = stages.size()
 	
@@ -363,7 +363,6 @@ func get_quest_structure() -> Array[Dictionary]:
 
 func set_quest_structure(structure: Array[Dictionary]) -> void:
 	if root == null or structure.is_empty():
-		sort_all()
 		return
 	
 	var stage_ids: Array[String] = []
@@ -469,15 +468,6 @@ func _sort_tree_alphabetically(a: TreeItem, b: TreeItem) -> bool:
 
 func _on_item_clicked(mouse_position: Vector2, mouse_button_index: int) -> void:
 	var selected: TreeItem = get_selected()
-	right_position = mouse_position
-	var add_text: String = "Add"
-	
-	if selected.get_metadata(0)["type"] == ItemType.QUEST:
-		add_text += " stage"
-	elif selected.get_metadata(0)["type"] == ItemType.STAGE:
-		add_text += " objective"
-	
-	quest_popup.set_item_text(quest_popup.get_item_index(PopupItemID.ADD_ITEM), add_text)
 	
 	match selected.get_metadata(0)["type"]:
 		ItemType.QUEST:
@@ -487,22 +477,33 @@ func _on_item_clicked(mouse_position: Vector2, mouse_button_index: int) -> void:
 		ItemType.OBJECTIVE:
 			objective_selected.emit(selected.get_parent().get_metadata(0)["id"], selected.get_metadata(0)["id"])
 	
-	if mouse_button_index == MOUSE_BUTTON_RIGHT:
-		quest_popup.position = DisplayServer.mouse_get_position()
-		quest_popup.set_item_disabled(
-			quest_popup.get_item_index(PopupItemID.REMOVE_ITEM),
-			selected.get_metadata(0)["type"] == ItemType.QUEST)
-		quest_popup.set_item_disabled(
-			quest_popup.get_item_index(PopupItemID.ADD_ITEM),
-			selected.get_metadata(0)["type"] == ItemType.OBJECTIVE)
-		quest_popup.set_item_disabled(
-				quest_popup.get_item_index(PopupItemID.SET_ENTRY),
-				selected.get_metadata(0)["type"] != ItemType.STAGE)
-		quest_popup.set_item_disabled(
-				quest_popup.get_item_index(PopupItemID.DUPLICATE),
-				selected.get_metadata(0)["type"] == ItemType.QUEST)
+	if mouse_button_index != MOUSE_BUTTON_RIGHT:
+		return
 		
-		quest_popup.popup()
+	right_position = mouse_position
+	var add_text: String = "Add"
+	
+	if selected.get_metadata(0)["type"] == ItemType.QUEST:
+		add_text += " stage"
+	elif selected.get_metadata(0)["type"] == ItemType.STAGE:
+		add_text += " objective"
+	quest_popup.set_item_text(quest_popup.get_item_index(PopupItemID.ADD_ITEM), add_text)
+	
+	quest_popup.position = DisplayServer.mouse_get_position()
+	quest_popup.set_item_disabled(
+		quest_popup.get_item_index(PopupItemID.REMOVE_ITEM),
+		selected.get_metadata(0)["type"] == ItemType.QUEST)
+	quest_popup.set_item_disabled(
+		quest_popup.get_item_index(PopupItemID.ADD_ITEM),
+		selected.get_metadata(0)["type"] == ItemType.OBJECTIVE)
+	quest_popup.set_item_disabled(
+			quest_popup.get_item_index(PopupItemID.SET_ENTRY),
+			selected.get_metadata(0)["type"] != ItemType.STAGE)
+	quest_popup.set_item_disabled(
+			quest_popup.get_item_index(PopupItemID.DUPLICATE),
+			selected.get_metadata(0)["type"] == ItemType.QUEST)
+	
+	quest_popup.popup()
 
 
 func _on_popup_id_pressed(id: int) -> void:

--- a/addons/nexus_forge/quests/quest_hierarchy_tree.gd
+++ b/addons/nexus_forge/quests/quest_hierarchy_tree.gd
@@ -173,12 +173,9 @@ func set_entry_stage(stage_id: StringName) -> void:
 
 
 func select_quest(emit_select: bool = true) -> void:
+	root.select(0)
 	if emit_select:
-		root.select(0)
-	else:
-		item_mouse_selected.disconnect(_on_item_clicked)
-		root.select(0)
-		item_mouse_selected.connect(_on_item_clicked, CONNECT_DEFERRED)
+		quest_selected.emit()
 
 
 func set_quest(quest: Quest, select: bool = false, emit_select: bool = true) -> void:
@@ -471,7 +468,7 @@ func _on_item_clicked(mouse_position: Vector2, mouse_button_index: int) -> void:
 	
 	match selected.get_metadata(0)["type"]:
 		ItemType.QUEST:
-			quest_selected.emit(selected.get_metadata(0)["id"])
+			quest_selected.emit()
 		ItemType.STAGE:
 			stage_selected.emit(selected.get_metadata(0)["id"])
 		ItemType.OBJECTIVE:

--- a/addons/nexus_forge/recipes/crafting_script.gd
+++ b/addons/nexus_forge/recipes/crafting_script.gd
@@ -855,7 +855,7 @@ func _set_ingredient_metadata_id(on_recipe: StringName, on_input: bool, on_ingre
 
 func _notification(what: int) -> void:
 	if what == NOTIFICATION_PREDELETE:
-		if undo != null and is_instance_valid(undo):
+		if is_instance_valid(undo):
 			undo.clear_history()
 			undo.free()
 			undo = null

--- a/addons/nexus_forge/resources/blackboard_storage.gd
+++ b/addons/nexus_forge/resources/blackboard_storage.gd
@@ -198,7 +198,7 @@ func erase_folder(folder_path: String) -> void:
 		folder_erased.emit(clean_path)
 
 
-## Returns true if folder in [param folder_oath] is empty or doesn't exist.
+## Returns true if folder in [param folder_path] is empty or doesn't exist.
 func is_folder_empty(folder_path: String) -> bool:
 	var clean_path: StringName = StringName(folder_path.simplify_path())
 	if _active_variables.has(clean_path) and not _active_variables[clean_path].is_empty():

--- a/addons/nexus_forge/resources/blackboard_storage.gd
+++ b/addons/nexus_forge/resources/blackboard_storage.gd
@@ -1,6 +1,6 @@
 @tool
 @icon("res://addons/nexus_forge/icons/variable_icon.svg")
-class_name BlackboardData
+class_name NFBlackboardData
 extends Resource
 ## A resource used to hold variables in a structured manner.
 ##

--- a/addons/nexus_forge/resources/dialog_storage/dialog_storage_base.gd
+++ b/addons/nexus_forge/resources/dialog_storage/dialog_storage_base.gd
@@ -20,7 +20,7 @@ enum LocalizationType {
 }
 
 ## The types of nodes.
-const NodeType := DialogParser.NodeTypes
+const NodeType := NFDialogParser.NodeTypes
 const LOCALE_STORE_MAX: int = 3
 
 ## The UUID of the entry node.

--- a/addons/nexus_forge/resources/dialog_storage/dialog_storage_editor.gd
+++ b/addons/nexus_forge/resources/dialog_storage/dialog_storage_editor.gd
@@ -499,17 +499,12 @@ func clear() -> void:
 ## Grabs all data, strips it of the editor information and returns its
 ## [DiscourseDialog] version for release. Inteded ONLY to be used by the 
 ## NexusForge export plugin.
-func convert_for_release() -> DiscourseDialog:
+func convert_for_release(api_methods: Dictionary[StringName, Dictionary]) -> DiscourseDialog:
 	var available_methods: Dictionary = preload("res://addons/nexus_forge/discourse/nodes/method_call_node.gd").get_user_methods()
 	var available_signals: Dictionary = preload("res://addons/nexus_forge/discourse/nodes/signal_node.gd").get_user_signals()
 	
 	var release_dialog: DiscourseDialog = DiscourseDialog.new()
-	var api: DiscourseAPI = DiscourseAPI.new()
-	var api_methods: Dictionary[StringName, Dictionary] = {}
 	var uuid_translator: Dictionary[StringName, StringName] = {}
-	
-	for method in api.get_method_list():
-		api_methods[StringName(method["name"])] = method
 	
 	release_dialog.entry_node = node_data[entry_node]["name"] if node_data.has(entry_node) else &""
 	
@@ -549,8 +544,6 @@ func convert_for_release() -> DiscourseDialog:
 	target_finder.anchor_nodes.assign(anchor_nodes)
 	target_finder.dialog_mergers.assign(dialog_mergers)
 	target_finder.uuid_to_id_conversions.assign(uuid_translator)
-	
-	#var add_id: bool = true
 	
 	for node_id in node_uuids:
 		var export_data: Dictionary[String, Variant] = {

--- a/addons/nexus_forge/resources/managers/quest_manager.gd
+++ b/addons/nexus_forge/resources/managers/quest_manager.gd
@@ -8,17 +8,17 @@ extends RefCounted
 ## It also provides methods to get data for storage and restoring it.
 
 
-## Emmited when a quest is started via [method start_quest].
+## Emitted when a quest is started via [method start_quest].
 signal quest_started(quest_id: StringName)
-## Emmited when a quest progresses. Emmited too when a quest starts with [param to_stage]
+## Emitted when a quest progresses. Emitted too when a quest starts with [param to_stage]
 ## being the entry stage.
 signal quest_progressed(quest_id: StringName, to_stage: StringName)
-## Emmited when a quest finishes either automatically or by using [method complete_quest]
+## Emitted when a quest finishes either automatically or by using [method complete_quest]
 signal quest_finished(quest_id: StringName)
 
-## Emmited when a quest stage is completed.
+## Emitted when a quest stage is completed.
 signal stage_completed(quest_id: StringName, stage_id: StringName, successfully: bool)
-## Emmited when a stage objective is completed.
+## Emitted when a stage objective is completed.
 signal objective_completed(quest_id: StringName, stage_id: StringName, objective_id: StringName, successfully: bool)
 
 ## Emits when a quest/stage/objective is completed either successfully or not.
@@ -56,7 +56,17 @@ func _get(property: StringName) -> Variant:
 ## And it'll auto-advance to the failed quest path if [param auto_advance_stages]
 ## was enabled.
 func start_quest(quest: Quest, auto_advance_stages: bool) -> bool:
-	if _active_quests.has(quest.id) or not quest.has_stage(quest.entry_stage):
+	if _active_quests.has(quest.id):
+		NFPluginGameHandler._log_msg(
+				"odyssey",
+				"Coulnd't start quest. Quest with ID '%s' is already active." % quest.id,
+				NFPluginGameHandler._LogLevel.ERROR)
+		return false
+	elif not quest.has_stage(quest.entry_stage):
+		NFPluginGameHandler._log_msg(
+				"odyssey",
+				"Coulnd't start quest '%s'. Quest doesn't have starting stage '%s'" % [quest.id, quest.entry_stage],
+				NFPluginGameHandler._LogLevel.ERROR)
 		return false
 	
 	if _quest_modifiers.has(quest.id) and not quest._mods_applied:
@@ -81,6 +91,10 @@ func start_quest(quest: Quest, auto_advance_stages: bool) -> bool:
 	quest_progressed.emit(quest.id, quest.entry_stage)
 	
 	if not new_entry.set_stage(quest.entry_stage, _static_progress):
+		NFPluginGameHandler._log_msg(
+				"odyssey",
+				"Failed to set stage '%s' for quest with ID '%s'" % [quest.entry_stage, quest.id],
+				NFPluginGameHandler._LogLevel.ERROR)
 		return false
 	
 	_check_stage_auto_advance(quest.id)
@@ -106,8 +120,9 @@ func add_quest_resource(quest: Quest, auto_advance_stages: bool, apply_mods: boo
 	new_entry.auto_advance_stages = auto_advance_stages
 	new_entry.current_stage = quest.entry_stage
 	new_entry._flags = BitUtils.set_bit_index(0, 0, true)
-	
 	_active_quests[quest.id] = new_entry
+	new_entry.objective_state_changed.connect(_on_quest_objective_state_changed)
+	
 	return true
 
 
@@ -170,6 +185,7 @@ func restore_state(state_data: Dictionary) -> void:
 			new_entry.auto_advance_stages = auto_advance
 			new_entry._flags = BitUtils.set_bit_index(0, 0, true)
 			_active_quests[key] = new_entry
+			new_entry.objective_state_changed.connect(_on_quest_objective_state_changed)
 		
 		var valid_progress: Dictionary[StringName, Dictionary] = {}
 		
@@ -200,7 +216,7 @@ func restore_state(state_data: Dictionary) -> void:
 			if not obj_progress.is_empty():
 				valid_progress[obj_id] = obj_progress
 		
-		_active_quests[key].set_stage(state_data[key]["current_stage"])
+		_active_quests[key].set_stage(state_data[key]["current_stage"], _static_progress, false)
 		_active_quests[key].set_objectives_state(valid_progress)
 
 
@@ -313,7 +329,7 @@ func set_objective_progress_of(quest: StringName, key: String, value: Variant) -
 ## completed successfully it'll continue to the next stage.
 ## [b]Note:[/b] Failing a required objective means that an auto-advancing quest
 ## will never progress and [signal QuestManager.stage_completed] won't be 
-## emmited if all objectives were completed so it must be progressed using 
+## emitted if all objectives were completed so it must be progressed using 
 ## [method QuestManager.complete_stage].
 func complete_objective(quest_id: StringName, stage_id: StringName, objective_id: StringName, success: bool) -> void:
 	if not _active_quests.has(quest_id) or not _active_quests[quest_id].resource.has_stage(stage_id) or not _active_quests[quest_id].resource.get_stage(stage_id).has_objective(objective_id):
@@ -332,20 +348,7 @@ func complete_objective(quest_id: StringName, stage_id: StringName, objective_id
 	_set_stage_complete(quest_id, stage_id, true)
 	stage_completed.emit(quest_id, stage_id, true)
 	
-	if next_stage.is_empty():
-		_set_quest_complete(quest_id, true)
-		_active_quests.erase(quest_id)
-		quest_finished.emit(quest_id)
-	else:
-		if entry.set_stage(next_stage, _static_progress):
-			quest_progressed.emit(quest_id, next_stage)
-			if not _static_progress.is_empty():
-				entry._scan_for_completed_objectives()
-		else:
-			NFPluginGameHandler._log_msg(
-					"odyssey - quest manager",
-					"Stage '%s' on quest '%s' not found." % [next_stage, quest_id],
-					NFPluginGameHandler._LogLevel.ERROR)
+	_check_stage_auto_advance(quest_id)
 
 
 ## Forces the completion of the [param stage_id] with a [param success] status.[br]
@@ -374,8 +377,6 @@ func complete_stage(quest_id: StringName, stage_id: StringName, success: bool) -
 	else:
 		if entry.set_stage(next_stage, _static_progress):
 			quest_progressed.emit(quest_id, next_stage)
-			if not _static_progress.is_empty():
-				entry._scan_for_completed_objectives()
 		else:
 			NFPluginGameHandler._log_msg(
 					"odyssey - quest manager",
@@ -476,28 +477,7 @@ func _on_quest_objective_state_changed(quest_id: StringName, stage_id: StringNam
 		_set_objective_complete(quest_id, stage_id, objective_id, true)
 		objective_completed.emit(quest_id, stage_id, objective_id, true)
 	
-	if not entry.auto_advance_stages or not entry.can_complete_stage():
-		return
-	
-	var next_stage: StringName = entry.resource.get_stage(stage_id).success_stage_id
-	
-	_set_stage_complete(quest_id, stage_id, true)
-	stage_completed.emit(quest_id, stage_id, true)
-	
-	if next_stage.is_empty():
-		_set_quest_complete(quest_id, true)
-		_active_quests.erase(quest_id)
-		quest_finished.emit(quest_id)
-	else:
-		if entry.set_stage(next_stage, _static_progress):
-			quest_progressed.emit(quest_id, next_stage)
-			if not _static_progress.is_empty():
-				entry._scan_for_completed_objectives()
-		else:
-			NFPluginGameHandler._log_msg(
-					"odyssey - quest manager",
-					"Stage '%s' on quest '%s' not found." % [next_stage, quest_id],
-					NFPluginGameHandler._LogLevel.ERROR)
+	_check_stage_auto_advance(quest_id)
 
 
 func _check_stage_auto_advance(quest_id: StringName) -> void:
@@ -755,15 +735,15 @@ class NFQuestEntry extends RefCounted:
 				_flags = f
 	
 	
-	func set_stage(stage_id: StringName, static_progress: Dictionary[String, Variant] = {}) -> bool:
+	func set_stage(stage_id: StringName, static_progress: Dictionary[String, Variant] = {}, initialize_stage: bool = true) -> bool:
 		if resource == null:
 			return false
-		elif not resource.has_stage(current_stage):
+		elif not resource.has_stage(stage_id):
 			return false
 		elif current_stage == stage_id:
 			return true
 		
-		var stage: QuestStage = resource.get_stage(current_stage)
+		var stage: QuestStage = resource.get_stage(stage_id)
 		_clear_trackers()
 		
 		for objective_id in stage.objectives():
@@ -776,7 +756,9 @@ class NFQuestEntry extends RefCounted:
 			_objective_tracker[objective_id] = progress_tracker
 			progress_tracker.state_updated.connect(_on_objective_state_changed)
 		
-		if not static_progress.is_empty():
+		_current_stage = stage_id
+		
+		if initialize_stage:
 			_initialize_stage()
 		
 		return true
@@ -801,6 +783,7 @@ class NFQuestEntry extends RefCounted:
 	func can_complete_stage(exclude_optional: bool = true) -> bool:
 		if _is_stage_initializing:
 			return false
+		
 		
 		for obj_id in _objective_tracker:
 			if not _objective_tracker[obj_id].is_required and exclude_optional:
@@ -856,12 +839,15 @@ class NFQuestEntry extends RefCounted:
 				valid_state[entry] = valid_entries
 		# ------------------
 		
-		for valid_entry in valid_state:
-			if _objective_tracker.has(valid_entry):
-				var tracker: NFObjectiveProgressTracker = _objective_tracker[valid_entry]
-				tracker._assign_progress(valid_state[valid_entry])
-				if not tracker._is_complete and tracker.can_complete():
-					tracker._is_complete = true
+		
+		for tracker_id in _objective_tracker:
+			var tracker: NFObjectiveProgressTracker = _objective_tracker[tracker_id]
+		
+			if valid_state.has(tracker_id):
+				tracker._assign_progress(valid_state[tracker_id])
+			
+			if not tracker._is_complete and tracker.can_complete():
+				tracker._is_complete = true
 	
 	
 	func _on_objective_state_changed(objective_id: StringName) -> void:
@@ -884,7 +870,7 @@ class NFObjectiveProgressTracker extends RefCounted:
 	var progress: Dictionary[String, Variant] = {
 		"inventory/apples": 2,
 		"inventory/oranges": 0}
-	var _requirements: Dictionary[String, Variant] = {
+	var _requirements: Dictionary[String, Dictionary] = {
 		"inventory/apples": {"operator": OP_GREATER_EQUAL, "value": 5},
 		"inventory/oranges": {"operator": OP_GREATER_EQUAL, "value": 1},
 		"time": {"operator": OP_LESS_EQUAL, "value": 720}}
@@ -940,12 +926,10 @@ class NFObjectiveProgressTracker extends RefCounted:
 	func _are_requirements_met() -> bool:
 		for entry in _requirements:
 			var current_progress_value = progress[entry] if progress.has(entry) else _get_default_value(_requirements[entry]["value"])
-			
 			if typeof(current_progress_value) == TYPE_NIL:
 				return false
 			elif not _perform_comparison(current_progress_value, _requirements[entry]["operator"], _requirements[entry]["value"]):
 				return false
-		
 		return true
 	
 	
@@ -971,7 +955,11 @@ class NFObjectiveProgressTracker extends RefCounted:
 			OP_GREATER_EQUAL:
 				return active_value >= target_value
 			_:
-				return true
+				NFPluginGameHandler._log_msg(
+						"odyssey - evaluator",
+						"Invalid operator '%s' used in requirement comparison." % operator,
+						NFPluginGameHandler._LogLevel.ERROR)
+				return false
 	
 	
 	func _get_default_value(of_variant: Variant) -> Variant:

--- a/addons/nexus_forge/resources/managers/quest_manager.gd
+++ b/addons/nexus_forge/resources/managers/quest_manager.gd
@@ -1,4 +1,4 @@
-class_name QuestManager
+class_name NFQuestManager
 extends RefCounted
 ## An object to manage and keep track of quests.
 ##
@@ -30,7 +30,8 @@ enum SuccessStatus{
 	UNKNOWN,
 }
 
-var _active_quests: Dictionary[StringName, QuestEntry] = {}
+var _active_quests: Dictionary[StringName, NFQuestEntry] = {}
+var _static_progress: Dictionary[String, Variant] = {}
 
 ## The quest log in which the history of quest started and finished is stored.
 var Log: NFQuestLog = NFQuestLog.new()
@@ -42,7 +43,7 @@ var _quest_modifiers: Dictionary[StringName, Dictionary] = {}
 func _get(property: StringName) -> Variant:
 	if _active_quests.has(property):
 		return property
-	var invalid: QuestEntry = QuestEntry.new()
+	var invalid: NFQuestEntry = NFQuestEntry.new()
 	invalid._flags = BitUtils.set_bit_index(0, 63, true)
 	return invalid
 
@@ -63,24 +64,26 @@ func start_quest(quest: Quest, auto_advance_stages: bool) -> bool:
 			if _quest_modifiers[quest.id]["mods"][id]["callable"].is_valid():
 				_quest_modifiers[quest.id]["mods"][id]["callable"].call(quest)
 	
-	var new_entry: QuestEntry = QuestEntry.new()
+	var new_entry: NFQuestEntry = NFQuestEntry.new()
 	new_entry.resource = quest
 	new_entry.auto_advance_stages = auto_advance_stages
-	new_entry.current_stage = quest.entry_stage
 	new_entry._flags = BitUtils.set_bit_index(0, 0, true)
-	
 	_active_quests[quest.id] = new_entry
+	new_entry.objective_state_changed.connect(_on_quest_objective_state_changed)
 	
 	var quest_entry: NFQuestLog.NFQuestLogEntry = Log.set_entry(quest.id)
-	
 	for stage_id in quest.stages():
 		var stage_entry: NFQuestLog.NFQuestLogStageEntry = quest_entry.set_entry(stage_id)
-		
 		for objective_id in quest.get_stage(stage_id).objectives():
 			stage_entry.set_entry(objective_id)
 	
 	quest_started.emit(quest.id)
 	quest_progressed.emit(quest.id, quest.entry_stage)
+	
+	if not new_entry.set_stage(quest.entry_stage, _static_progress):
+		return false
+	
+	_check_stage_auto_advance(quest.id)
 	
 	return true
 
@@ -98,7 +101,7 @@ func add_quest_resource(quest: Quest, auto_advance_stages: bool, apply_mods: boo
 			if _quest_modifiers[quest.id]["mods"][id]["callable"].is_valid():
 				_quest_modifiers[quest.id]["mods"][id]["callable"].call(quest)
 	
-	var new_entry: QuestEntry = QuestEntry.new()
+	var new_entry: NFQuestEntry = NFQuestEntry.new()
 	new_entry.resource = quest
 	new_entry.auto_advance_stages = auto_advance_stages
 	new_entry.current_stage = quest.entry_stage
@@ -113,34 +116,20 @@ func add_quest_resource(quest: Quest, auto_advance_stages: bool, apply_mods: boo
 func get_state() -> Dictionary[StringName, Dictionary]:
 	var data: Dictionary[StringName, Dictionary] = {}
 	
-	for quest_id in _active_quests.keys():
-		var stages: Dictionary[StringName, Dictionary] = {}
+	for quest_id in _active_quests:
 		var quest: Dictionary[String, Variant] = {
 			"resource_path": _active_quests[quest_id].resource.resource_path,
 			"current_stage": _active_quests[quest_id].current_stage,
 			"auto_advance_stages": _active_quests[quest_id].auto_advance_stages,
-			"stages": stages}
+			"stage_progress": _active_quests[quest_id].get_objectives_state()}
 		
-		for stage_id in _active_quests[quest_id].resource.stages():
-			var stage: QuestStage = _active_quests[quest_id].resource.get_stage(stage_id)
-			var objective_data: Dictionary[StringName, Dictionary] = {}
-			for objective_id in stage.objectives():
-				var objective: QuestObjective = stage.get_objective(objective_id)
-				if objective == null:
-					NFPluginGameHandler._log_msg(
-							"quests",
-							"Couldn't load objective data of '%s' from quest '%s' on stage '%s'" % [objective_id, quest_id, stage_id],
-							NFPluginGameHandler._LogLevel.ERROR)
-					continue
-				objective_data[objective_id] = objective._progress.duplicate(true)
-			stages[stage_id] = objective_data
 		data[quest_id] = quest
 	return data
 
 
 ## Restores a previous state of the manager.
 func restore_state(state_data: Dictionary) -> void:
-	for key in state_data.keys():
+	for key in state_data:
 		var key_type: int = typeof(key)
 		if key_type != TYPE_STRING_NAME and key_type != TYPE_STRING:
 			continue
@@ -151,10 +140,14 @@ func restore_state(state_data: Dictionary) -> void:
 		if not _is_serialized_data_valid(key, state_data[key]):
 			continue
 		
-		if state_data[key]["resource_path"].is_empty():
-			continue
+		var res: Quest = null
 		
-		var res = _active_quests[key] if _active_quests.has(key) else load(state_data["resource_path"]) 
+		if _active_quests.has(key):
+			res = _active_quests[key].resource
+		else:
+			var pre = load(state_data[key]["resource_path"])
+			if pre != null and pre is Quest:
+				res = pre
 		
 		if res == null or res is not Quest:
 			NFPluginGameHandler._log_msg(
@@ -162,99 +155,53 @@ func restore_state(state_data: Dictionary) -> void:
 				"Resource for quest '%s' couldn't be loaded. Skipping." % key,
 				NFPluginGameHandler._LogLevel.WARNING)
 			continue
-	
+		
 		if _quest_modifiers.has(key) and not res._mods_applied:
 			for id in _quest_modifiers[key]["order"]:
 				if _quest_modifiers[key]["mods"][id]["callable"].is_valid():
 					_quest_modifiers[key]["mods"][id]["callable"].call(res)
 		
-		for stage_id in state_data[key]["stages"].keys():
-			var stage_type: int = typeof(stage_id)
-			if stage_type != TYPE_STRING_NAME and stage_type != TYPE_STRING:
+		if not _active_quests.has(key):
+			var new_entry: NFQuestEntry = NFQuestEntry.new()
+			var auto_advance: bool = false
+			if state_data[key].has("auto_advance_stages") and typeof(state_data[key]["auto_advance_stages"]) == TYPE_BOOL:
+				auto_advance = state_data[key]["auto_advance_stages"]
+			new_entry.resource = res
+			new_entry.auto_advance_stages = auto_advance
+			new_entry._flags = BitUtils.set_bit_index(0, 0, true)
+			_active_quests[key] = new_entry
+		
+		var valid_progress: Dictionary[StringName, Dictionary] = {}
+		
+		for obj_id in state_data[key]["stage_progress"]:
+			var id_type: int = typeof(obj_id)
+			if id_type != TYPE_STRING and id_type != TYPE_STRING_NAME:
 				continue
-			if typeof(state_data[key]["stages"][stage_id]) != TYPE_DICTIONARY:
+			
+			if typeof(state_data[key]["stage_progress"][obj_id]) != TYPE_DICTIONARY:
 				NFPluginGameHandler._log_msg(
 						"quests - deserializer",
-						"Error on provided data of stage '%s' from quest '%s'. Skipping." % [stage_id, key],
+						"Objective '%s' data mismatch on quest '%s'. Skipping." % [obj_id, key],
 						NFPluginGameHandler._LogLevel.WARNING)
 				continue
 			
-			if not res.has_stage(stage_id):
-				NFPluginGameHandler._log_msg(
-						"quests - deserializer",
-						"Stage '%s' does not exist on quest '%s'. Skipping." % [stage_id, key],
-						NFPluginGameHandler._LogLevel.WARNING)
-				continue
-			var stage: QuestStage = res.get_stage(stage_id)
-			var stage_data: Dictionary = state_data[key]["stages"][stage_id]
-			for objective_id in stage_data.keys():
-				var obj_type: int = typeof(objective_id)
-				if obj_type != TYPE_STRING_NAME and obj_type != TYPE_STRING:
-					continue
-				if not stage.has_objective(objective_id):
+			var obj_progress: Dictionary[String, Variant] = {}
+			
+			for inner_id in state_data[key]["stage_progress"][obj_id]:
+				var inner_id_type: int = typeof(inner_id)
+				if inner_id_type != TYPE_STRING and inner_id_type != TYPE_STRING_NAME:
 					NFPluginGameHandler._log_msg(
 							"quests - deserializer",
-							"Objective '%s' does not exist in stage '%s' on quest '%s'. Skipping." % [objective_id, stage_id, key],
+							"Objective '%s' progress key data missmatch on quest '%s'. Skipping." % [obj_id, key],
 							NFPluginGameHandler._LogLevel.WARNING)
 					continue
-				if typeof(stage_data[objective_id]) != TYPE_DICTIONARY:
-					NFPluginGameHandler._log_msg(
-							"quests - deserializer",
-							"Error on provided data of objective '%s' from stage '%s' on quest '%s'. Skipping." % [objective_id, stage_id, key],
-							NFPluginGameHandler._LogLevel.WARNING)
-					continue
-				var objective: QuestObjective = stage.get_objective(objective_id)
-				var obj_progress: Dictionary[String, Variant] = {}
-				for progress_key in stage_data[objective_id].keys():
-					var pr_type: int = typeof(progress_key)
-					if pr_type != TYPE_STRING and pr_type != TYPE_STRING_NAME:
-						NFPluginGameHandler._log_msg(
-								"quests - deserializer",
-								"Invalid objective data key on objective '%s' in stage '%s' on quest '%s'. Skipping progress entry." % [objective_id, stage_id, key],
-								NFPluginGameHandler._LogLevel.WARNING)
-						continue
-					obj_progress[progress_key] = stage_data[objective_id][progress_key]
-				objective._progress.assign(obj_progress)
-
-
-func _is_serialized_data_valid(quest: StringName, data: Dictionary) -> bool:
-	if not data.has_all(["resource_path", "current_stage", "stages"]):
-		NFPluginGameHandler._log_msg(
-				"quests - deserializer",
-				"Provided data for quest '%s' is missing entries.",
-				NFPluginGameHandler._LogLevel.ERROR)
-		return false
-	
-	if typeof(data["resource_path"]) != TYPE_STRING:
-		NFPluginGameHandler._log_msg(
-				"quests - deserializer",
-				"Invalid resource path given for quest '%s'" % quest,
-				NFPluginGameHandler._LogLevel.ERROR)
-		return false
-	
-	if data["resource_path"].is_empty() or not ResourceLoader.exists(data["resource_path"]):
-		NFPluginGameHandler._log_msg(
-				"quests - deserializer",
-				"Resource path '%s' for quest '%s' is empty or does not exist." % [data["resource_path"], quest],
-				NFPluginGameHandler._LogLevel.ERROR)
-		return false
-	
-	var stage_type = typeof(data["current_stage"])
-	
-	if stage_type != TYPE_STRING_NAME and stage_type != TYPE_STRING:
-		NFPluginGameHandler._log_msg(
-				"quests - deserializer",
-				"Invalid data for stage value on quest '%s'" % quest,
-				NFPluginGameHandler._LogLevel.ERROR)
-		return false
-	
-	if typeof(data["stages"]) != TYPE_DICTIONARY:
-		NFPluginGameHandler._log_msg(
-				"quests - deserializer",
-				"Invalid data for stages value on quest '%s'" % quest,
-				NFPluginGameHandler._LogLevel.ERROR)
-		return false
-	return true
+				obj_progress[inner_id] = state_data[key]["stage_progress"][obj_id][inner_id]
+			
+			if not obj_progress.is_empty():
+				valid_progress[obj_id] = obj_progress
+		
+		_active_quests[key].set_stage(state_data[key]["current_stage"])
+		_active_quests[key].set_objectives_state(valid_progress)
 
 
 ## Removes an active quest and clears it from the history if
@@ -317,77 +264,88 @@ func objective_success_status(quest_id: StringName, stage_id: StringName, object
 	return SuccessStatus.UNKNOWN
 
 
-## Sets the progress of [param objective_id] to [param progress_value]. If
-## all requirements of the objective are met [signal objective_completed] will be emmited.[br]
-## If a quest is set to auto-advance and all the required objectives of [param stage_id]
-## are completed it'll trigger it to advance to the next stage.[br][br]
-## [b][color=KHAKI]Important:[/color][/b] To keep track of progress correctly it is reccomended to set the
-## objectives' progress through this method instead of directly to the QuestObjective
-## object directly.
-func set_objective_progress(quest_id: StringName, stage_id: StringName, objective_id: StringName, requirement_id: String, progress_value) -> void:
-	if not DictUtils.has_nested_path(_active_quests, [quest_id, "quest"]):
+## Registers a global [param key] with a [param value] that will be instantly 
+## passed to all currently active quests, as well as any future quests when
+## they start.
+## [br]Calling [method QuestManager.set_objective_progress] with a matching key will
+## automatically update this static registry.
+## [br][br][b][color=KHAKI]Important:[/color][/b] Quests could progress
+## immediately upon registration or starting if the static values fulfill
+## all required objectives.
+func register_static_progress(key: String, value: Variant) -> void:
+	_static_progress[key] = value
+	_update_objective_progress(key, value)
+
+
+## Removes a static progress [param key] previously registered via 
+## [method register_static_progress]. 
+## [br]Returns [code]true[/code] if the key was found and successfully removed.
+func erase_static_progress(key: String) -> bool:
+	return _static_progress.erase(key)
+
+
+## Updates the objective progress for ALL active quests. If the provided
+## [param key] is registered globally, it will also update the static progress
+## registry.
+## [br][br]If a quest is set to [code]auto_advance_stages[/code] and this update 
+## completes all of its required objectives, the quest will automatically advance 
+## to its next stage.
+func set_objective_progress(key: String, value: Variant) -> void:
+	if _static_progress.has(key):
+		_static_progress[key] = value
+	_update_objective_progress(key, value)
+
+
+## Updates the objective progress for a specific [param quest]. 
+## [br]Unlike [method QuestManager.set_objective_progress], this will
+## NOT update any registered static progress, even if the [param key] matches.
+func set_objective_progress_of(quest: StringName, key: String, value: Variant) -> void:
+	if not _active_quests.has(quest):
 		return
 	
-	var quest: Quest = _active_quests[quest_id].resource
-	
-	if not quest.has_stage(stage_id) or not quest.get_stage(stage_id).has_objective(objective_id) or not quest.get_stage(stage_id).get_objective(objective_id).has_requirement(requirement_id):
-		return
-	
-	var quest_objective: QuestObjective = quest.get_stage(stage_id).get_objective(objective_id)
-	quest_objective.set_progress(requirement_id, progress_value)
-	
-	if quest_objective.can_complete_objective():
-		_set_objective_complete(quest_id, stage_id, objective_id, true)
-		objective_completed.emit(quest_id, stage_id, objective_id, true)
-		
-		var quest_stage: QuestStage = quest.get_stage(stage_id)
-		
-		if not _active_quests[quest_id].auto_advance_stages or not quest_stage.can_complete_stage():
-			return
-		
-		if quest_stage.success_stage_id.is_empty():
-			_set_quest_complete(quest_id, true)
-			_active_quests.erase(quest_id)
-			quest_finished.emit(quest_id)
-		else:
-			_set_stage_complete(quest_id, stage_id, true)
-			_active_quests[quest_id].current_stage = quest_stage.success_stage_id
-			stage_completed.emit(quest_id, stage_id, true)
-			quest_progressed.emit(quest_id, quest_stage.success_stage_id)
+	_active_quests[quest].update_objective_progress(
+			key,
+			value)
 
 
 ## Forces the completion of the [param objective_id] with a [param success] status.[br]
 ## If a quest is set to auto-advance and all the required objectives are
 ## completed successfully it'll continue to the next stage.
 ## [b]Note:[/b] Failing a required objective means that an auto-advancing quest
-## will never progress and [signal stage_completed] won't be emmited if all
-## objectives were completed so it must be progressed using [method complete_stage].
+## will never progress and [signal QuestManager.stage_completed] won't be 
+## emmited if all objectives were completed so it must be progressed using 
+## [method QuestManager.complete_stage].
 func complete_objective(quest_id: StringName, stage_id: StringName, objective_id: StringName, success: bool) -> void:
 	if not _active_quests.has(quest_id) or not _active_quests[quest_id].resource.has_stage(stage_id) or not _active_quests[quest_id].resource.get_stage(stage_id).has_objective(objective_id):
 		return
-	var stage: QuestStage = _active_quests[quest_id].resource.get_stage(stage_id)
-	_set_objective_complete(quest_id, stage_id, objective_id, success)
 	
+	var entry: NFQuestEntry = _active_quests[quest_id]
+	
+	_set_objective_complete(quest_id, stage_id, objective_id, success)
 	objective_completed.emit(quest_id, stage_id, objective_id, success)
 	
-	var can_complete_stage: bool = stage.can_complete_stage()
-	
-	if can_complete_stage:
-		_set_stage_complete(quest_id, stage_id, true)
-		stage_completed.emit(quest_id, stage_id, true)
-	
-	if not _active_quests[quest_id].auto_advance_stages or not can_complete_stage:
+	if not entry.auto_advance_stages or not entry.can_complete_stage():
 		return
 	
-	var next_stage_id: StringName = stage.success_stage_id if success else stage.failure_stage_id
+	var next_stage: StringName = entry.resource.get_stage(stage_id).success_stage_id
 	
-	if next_stage_id.is_empty():
-		_set_quest_complete(quest_id, success)
+	_set_stage_complete(quest_id, stage_id, true)
+	stage_completed.emit(quest_id, stage_id, true)
+	
+	if next_stage.is_empty():
+		_set_quest_complete(quest_id, true)
 		_active_quests.erase(quest_id)
 		quest_finished.emit(quest_id)
 	else:
-		_active_quests[quest_id].current_stage = next_stage_id
-		quest_progressed.emit(quest_id, next_stage_id)
+		if entry.set_stage(next_stage, _static_progress):
+			quest_progressed.emit(quest_id, next_stage)
+			if not _static_progress.is_empty():
+				entry._scan_for_completed_objectives()
+		else:
+			NFPluginGameHandler._log_msg(
+					"odyssey - quest manager",
+					"Stage '%s' on quest '%s' not found." % [next_stage, quest_id],
+					NFPluginGameHandler._LogLevel.ERROR)
 
 
 ## Forces the completion of the [param stage_id] with a [param success] status.[br]
@@ -403,16 +361,26 @@ func complete_stage(quest_id: StringName, stage_id: StringName, success: bool) -
 	if not _active_quests[quest_id].auto_advance_stages:
 		return
 	
-	var stage: QuestStage = _active_quests[quest_id].resource.get_stage(stage_id)
-	var next_stage_id: StringName = stage.success_stage_id if success else stage.failure_stage_id
+	var entry: NFQuestEntry = _active_quests[quest_id]
+	var next_stage: StringName = entry.resource.get_stage(stage_id).success_stage_id
 	
-	if next_stage_id.is_empty():
-		_set_quest_complete(quest_id, success)
+	_set_stage_complete(quest_id, stage_id, true)
+	stage_completed.emit(quest_id, stage_id, true)
+	
+	if next_stage.is_empty():
+		_set_quest_complete(quest_id, true)
 		_active_quests.erase(quest_id)
-		quest_finished.emit(quest_id, success)
+		quest_finished.emit(quest_id)
 	else:
-		_active_quests[quest_id].current_stage = next_stage_id
-		quest_progressed.emit(quest_id, next_stage_id)
+		if entry.set_stage(next_stage, _static_progress):
+			quest_progressed.emit(quest_id, next_stage)
+			if not _static_progress.is_empty():
+				entry._scan_for_completed_objectives()
+		else:
+			NFPluginGameHandler._log_msg(
+					"odyssey - quest manager",
+					"Stage '%s' on quest '%s' not found." % [next_stage, quest_id],
+					NFPluginGameHandler._LogLevel.ERROR)
 
 
 ## Forces the completion of the [param quest_id] with a [param success] status.[br]
@@ -500,15 +468,84 @@ func remove_quest_modifier(for_quest: StringName, mod_id: StringName) -> void:
 		_quest_modifiers[for_quest]["order"].erase(mod_id)
 
 
+func _on_quest_objective_state_changed(quest_id: StringName, stage_id: StringName, objective_id: StringName) -> void:
+	var entry: NFQuestEntry = _active_quests[quest_id]
+	var objective_complete: bool = entry.get_objective_tracker(objective_id).can_complete()
+	
+	if objective_complete:
+		_set_objective_complete(quest_id, stage_id, objective_id, true)
+		objective_completed.emit(quest_id, stage_id, objective_id, true)
+	
+	if not entry.auto_advance_stages or not entry.can_complete_stage():
+		return
+	
+	var next_stage: StringName = entry.resource.get_stage(stage_id).success_stage_id
+	
+	_set_stage_complete(quest_id, stage_id, true)
+	stage_completed.emit(quest_id, stage_id, true)
+	
+	if next_stage.is_empty():
+		_set_quest_complete(quest_id, true)
+		_active_quests.erase(quest_id)
+		quest_finished.emit(quest_id)
+	else:
+		if entry.set_stage(next_stage, _static_progress):
+			quest_progressed.emit(quest_id, next_stage)
+			if not _static_progress.is_empty():
+				entry._scan_for_completed_objectives()
+		else:
+			NFPluginGameHandler._log_msg(
+					"odyssey - quest manager",
+					"Stage '%s' on quest '%s' not found." % [next_stage, quest_id],
+					NFPluginGameHandler._LogLevel.ERROR)
+
+
+func _check_stage_auto_advance(quest_id: StringName) -> void:
+	if not _active_quests.has(quest_id):
+		return
+	
+	var entry: NFQuestEntry = _active_quests[quest_id]
+	
+	while entry.auto_advance_stages and entry.can_complete_stage():
+		var stage_id: StringName = entry.current_stage
+		var next_stage: StringName = entry.resource.get_stage(stage_id).success_stage_id
+	
+		_set_stage_complete(quest_id, stage_id, true)
+		stage_completed.emit(quest_id, stage_id, true)
+	
+		if next_stage.is_empty():
+			_set_quest_complete(quest_id, true)
+			_active_quests.erase(quest_id)
+			quest_finished.emit(quest_id)
+			break
+		else:
+			quest_progressed.emit(quest_id, next_stage)
+			if not entry.set_stage(next_stage, _static_progress):
+				NFPluginGameHandler._log_msg(
+						"odyssey - quest manager",
+						"Stage '%s' on quest '%s' not found." % [next_stage, quest_id],
+						NFPluginGameHandler._LogLevel.ERROR)
+				break
+
+
 func _set_quest_complete(quest_id: StringName, success: bool, emit_events: bool = true) -> void:
 	var quest: Quest = _active_quests[quest_id].resource
 	
-	Log.set_entry(quest_id, SuccessStatus.SUCCESS if success else SuccessStatus.FAILURE)
+	Log.set_entry(
+			quest_id,
+			SuccessStatus.SUCCESS if success else SuccessStatus.FAILURE)
 	
 	if not emit_events:
 		return
 	
-	var events: Dictionary[String, Variant] = quest.on_success_events if success else quest.on_failure_events
+	var events: Dictionary[String, Variant] = {}
+	
+	if success:
+		if quest.events.has(&"success"):
+			events.assign(quest.events[&"success"])
+	else:
+		if quest.events.has(&"failure"):
+			events.assign(quest.events[&"failure"])
 	
 	quest_event_triggered.emit(events.duplicate(true))
 
@@ -521,19 +558,34 @@ func _set_stage_complete(quest_id: StringName, stage_id: StringName, success: bo
 	if not emit_events:
 		return
 	
-	var events: Dictionary[String, Variant] = stage.on_success_events if success else stage.on_failure_events
+	var events: Dictionary[String, Variant] = {}
+	
+	if success:
+		if stage.events.has(&"success"):
+			events.assign(stage.events[&"success"])
+	else:
+		if stage.events.has(&"failure"):
+			events.assign(stage.events[&"failure"])
+	
 	quest_event_triggered.emit(events.duplicate(true))
 
 
 func _set_objective_complete(quest_id: StringName, stage_id: StringName, objective_id: StringName, success: bool, emit_events: bool = true) -> void:
 	var objective: QuestObjective = _active_quests[quest_id].resource.get_stage(stage_id).get_objective(objective_id)
-	objective.set_completed(true)
 	_log_objective_complete(quest_id, stage_id, objective_id, success)
 	
 	if not emit_events:
 		return
 	
-	var events: Dictionary = objective.on_success_events if success else objective.on_failure_events
+	var events: Dictionary[String, Variant] = {}
+	
+	if success:
+		if objective.events.has(&"success"):
+			events.assign(objective.events[&"success"])
+	else:
+		if objective.events.has(&"failure"):
+			events.assign(objective.events[&"failure"])
+	
 	quest_event_triggered.emit(events.duplicate(true))
 
 
@@ -632,14 +684,321 @@ func _is_dependency_circular(on_quest: StringName, mod_id: StringName, depends_o
 		return _is_dependency_circular(on_quest, mod_id, dependency, _visited)
 
 
-class QuestEntry extends RefCounted:
-	var resource: Quest = null
+func _update_objective_progress(for_key: String, value: Variant) -> void:
+	for quest_id in _active_quests:
+		_active_quests[quest_id].update_objective_progress(
+				for_key,
+				value)
+
+
+func _is_serialized_data_valid(quest: StringName, data: Dictionary) -> bool:
+	if not data.has_all(["resource_path", "current_stage", "stage_progress"]):
+		NFPluginGameHandler._log_msg(
+				"quests - deserializer",
+				"Provided data for quest '%s' is missing entries." % quest,
+				NFPluginGameHandler._LogLevel.ERROR)
+		return false
+	
+	if typeof(data["resource_path"]) != TYPE_STRING:
+		NFPluginGameHandler._log_msg(
+				"quests - deserializer",
+				"Invalid resource path given for quest '%s'" % quest,
+				NFPluginGameHandler._LogLevel.ERROR)
+		return false
+	
+	if data["resource_path"].is_empty() or not ResourceLoader.exists(data["resource_path"]):
+		NFPluginGameHandler._log_msg(
+				"quests - deserializer",
+				"Resource path '%s' for quest '%s' is empty or does not exist." % [data["resource_path"], quest],
+				NFPluginGameHandler._LogLevel.ERROR)
+		return false
+	
+	var stage_type = typeof(data["current_stage"])
+	
+	if stage_type != TYPE_STRING_NAME and stage_type != TYPE_STRING:
+		NFPluginGameHandler._log_msg(
+				"quests - deserializer",
+				"Invalid data for stage value on quest '%s'" % quest,
+				NFPluginGameHandler._LogLevel.ERROR)
+		return false
+	
+	if typeof(data["stage_progress"]) != TYPE_DICTIONARY:
+		NFPluginGameHandler._log_msg(
+				"quests - deserializer",
+				"Invalid data for stage progress value on quest '%s'" % quest,
+				NFPluginGameHandler._LogLevel.ERROR)
+		return false
+	return true
+
+
+class NFQuestEntry extends RefCounted:
+	signal objective_state_changed(quest_id: StringName, stage_id: StringName, objective_id: StringName)
+	
+	var resource: Quest = null: # Blueprint
+		set(r):
+			if r == null and resource != null:
+				_current_stage = &""
+				_clear_trackers()
+			resource = r
 	var auto_advance_stages: bool = false
-	var current_stage: StringName = &""
+	var current_stage: StringName = &"":
+		set(s):
+			return
+		get():
+			return _current_stage
+	var _current_stage: StringName = &""
+	var _objective_tracker: Dictionary[StringName, NFObjectiveProgressTracker] = {}
+	var _is_stage_initializing: bool = false
 	var _flags: int = 0:
 		set(f):
 			if _flags == 0:
 				_flags = f
 	
+	
+	func set_stage(stage_id: StringName, static_progress: Dictionary[String, Variant] = {}) -> bool:
+		if resource == null:
+			return false
+		elif not resource.has_stage(current_stage):
+			return false
+		elif current_stage == stage_id:
+			return true
+		
+		var stage: QuestStage = resource.get_stage(current_stage)
+		_clear_trackers()
+		
+		for objective_id in stage.objectives():
+			var objective: QuestObjective = stage.get_objective(objective_id)
+			var progress_tracker: NFObjectiveProgressTracker = NFObjectiveProgressTracker.new()
+			progress_tracker.objective_id = objective_id
+			progress_tracker.is_required = stage.is_objective_required(objective_id)
+			progress_tracker._requirements = objective._requirements
+			progress_tracker._assign_progress(static_progress)
+			_objective_tracker[objective_id] = progress_tracker
+			progress_tracker.state_updated.connect(_on_objective_state_changed)
+		
+		if not static_progress.is_empty():
+			_initialize_stage()
+		
+		return true
+	
+	
+	func _initialize_stage() -> void:
+		_is_stage_initializing = true
+		
+		for id in _objective_tracker:
+			var tracker: NFObjectiveProgressTracker = _objective_tracker[id]
+			
+			if not tracker._is_complete and tracker.can_complete():
+				tracker._is_complete = true
+				objective_state_changed.emit(
+						resource.id,
+						current_stage,
+						id)
+		
+		_is_stage_initializing = false
+	
+	
+	func can_complete_stage(exclude_optional: bool = true) -> bool:
+		if _is_stage_initializing:
+			return false
+		
+		for obj_id in _objective_tracker:
+			if not _objective_tracker[obj_id].is_required and exclude_optional:
+				continue
+			if not _objective_tracker[obj_id].can_complete():
+				return false
+		return true
+	
+	
 	func is_valid() -> bool:
 		return BitUtils.is_bit_index(_flags, 0, true)
+	
+	
+	func update_objective_progress(key: String, value: Variant) -> void:
+		for tracker_id in _objective_tracker:
+			_objective_tracker[tracker_id].set_progress(key, value)
+	
+	
+	func get_objectives_state() -> Dictionary[StringName, Dictionary]:
+		var state: Dictionary[StringName, Dictionary] = {}
+		for tracker_id in _objective_tracker:
+			state[tracker_id] = _objective_tracker[tracker_id].progress.duplicate(true)
+		return state
+	
+	
+	func get_objective_tracker(objective_id: StringName) -> NFObjectiveProgressTracker:
+		if _objective_tracker.has(objective_id):
+			return _objective_tracker[objective_id]
+		return null
+	
+	
+	func set_objectives_state(state: Dictionary) -> void:
+		var valid_state: Dictionary[StringName, Dictionary] = {}
+		
+		# --- Validation ---
+		for entry in state:
+			var entry_type: int = typeof(entry)
+			if entry_type != TYPE_STRING_NAME and entry_type != TYPE_STRING:
+				continue
+			var value_type: int = typeof(state[entry])
+			if value_type != TYPE_DICTIONARY:
+				continue
+			
+			var valid_entries: Dictionary[String, Variant] = {}
+			
+			for state_entry in state[entry]:
+				var entry_value_type: int = typeof(state_entry)
+				if entry_value_type != TYPE_STRING and entry_value_type != TYPE_STRING_NAME:
+					continue
+				valid_entries[state_entry] = state[entry][state_entry]
+			
+			if not valid_entries.is_empty():
+				valid_state[entry] = valid_entries
+		# ------------------
+		
+		for valid_entry in valid_state:
+			if _objective_tracker.has(valid_entry):
+				var tracker: NFObjectiveProgressTracker = _objective_tracker[valid_entry]
+				tracker._assign_progress(valid_state[valid_entry])
+				if not tracker._is_complete and tracker.can_complete():
+					tracker._is_complete = true
+	
+	
+	func _on_objective_state_changed(objective_id: StringName) -> void:
+		objective_state_changed.emit(resource.id, current_stage, objective_id)
+	
+	
+	func _clear_trackers() -> void:
+		for id in _objective_tracker:
+			_objective_tracker[id].state_updated.disconnect(_on_objective_state_changed)
+			# Clear the reference for safety
+			_objective_tracker[id]._requirements = {}
+		_objective_tracker.clear()
+
+
+class NFObjectiveProgressTracker extends RefCounted:
+	signal state_updated(objective_id: StringName)
+	
+	var objective_id: StringName
+	var is_required: bool
+	var progress: Dictionary[String, Variant] = {
+		"inventory/apples": 2,
+		"inventory/oranges": 0}
+	var _requirements: Dictionary[String, Variant] = {
+		"inventory/apples": {"operator": OP_GREATER_EQUAL, "value": 5},
+		"inventory/oranges": {"operator": OP_GREATER_EQUAL, "value": 1},
+		"time": {"operator": OP_LESS_EQUAL, "value": 720}}
+	var _is_complete: bool = false
+	
+	
+	func get_progress() -> Array[Dictionary]:
+		var progress_array: Array[Dictionary] = []
+		for key in _requirements:
+			progress_array.append({
+				"key": key,
+				"required": _requirements[key]["value"],
+				"operator": _requirements[key]["operator"],
+				"current": progress[key] if progress.has(key) else _get_default_value(_requirements[key]["value"])})
+		return progress_array
+	
+	
+	func clear() -> void:
+		_requirements = {}
+		progress.clear()
+	
+	
+	func can_complete() -> bool:
+		if _is_complete:
+			return true
+		return _are_requirements_met()
+	
+	
+	func set_progress(key: String, value: Variant) -> void:
+		if not _requirements.has(key):
+			return
+		
+		progress[key] = value
+		var was_complete: bool = _is_complete
+		
+		_validate_progress()
+		
+		if was_complete and not _is_complete:
+			state_updated.emit(objective_id)
+		elif not was_complete and can_complete():
+			_is_complete = true
+			state_updated.emit(objective_id)
+	
+	
+	func _validate_progress() -> void:
+		if not _is_complete:
+			return
+		
+		if not _are_requirements_met():
+			_is_complete = false
+	
+	
+	func _are_requirements_met() -> bool:
+		for entry in _requirements:
+			var current_progress_value = progress[entry] if progress.has(entry) else _get_default_value(_requirements[entry]["value"])
+			
+			if typeof(current_progress_value) == TYPE_NIL:
+				return false
+			elif not _perform_comparison(current_progress_value, _requirements[entry]["operator"], _requirements[entry]["value"]):
+				return false
+		
+		return true
+	
+	
+	func _assign_progress(new_progress: Dictionary[String, Variant]) -> void:
+		progress.clear()
+		for key in new_progress:
+			if _requirements.has(key):
+				progress[key] = new_progress[key]
+	
+	
+	func _perform_comparison(active_value: Variant, operator: int, target_value: Variant) -> bool:
+		match operator:
+			OP_EQUAL:
+				return active_value == target_value
+			OP_NOT_EQUAL:
+				return active_value != target_value
+			OP_LESS:
+				return active_value < target_value
+			OP_LESS_EQUAL:
+				return active_value <= target_value
+			OP_GREATER:
+				return active_value > target_value
+			OP_GREATER_EQUAL:
+				return active_value >= target_value
+			_:
+				return true
+	
+	
+	func _get_default_value(of_variant: Variant) -> Variant:
+		match typeof(of_variant):
+			TYPE_INT:
+				return 0
+			TYPE_FLOAT:
+				return 0.0
+			TYPE_BOOL:
+				return false
+			TYPE_STRING:
+				return ""
+			TYPE_VECTOR2:
+				return Vector2.ZERO
+			TYPE_VECTOR2I:
+				return Vector2i.ZERO
+			TYPE_VECTOR3:
+				return Vector3.ZERO
+			TYPE_VECTOR3I:
+				return Vector3i.ZERO
+			TYPE_VECTOR4:
+				return Vector4.ZERO
+			TYPE_VECTOR4I:
+				return Vector4i.ZERO
+			TYPE_ARRAY:
+				return []
+			TYPE_DICTIONARY:
+				return {}
+			_:
+				return null

--- a/addons/nexus_forge/resources/parser/discourse_parser_base.gd
+++ b/addons/nexus_forge/resources/parser/discourse_parser_base.gd
@@ -1,4 +1,4 @@
-class_name DialogParser
+class_name NFDialogParser
 extends RefCounted
 ## The parser that NexusForge will use while its running on exported projects.
 ##

--- a/addons/nexus_forge/resources/parser/discourse_parser_editor.gd
+++ b/addons/nexus_forge/resources/parser/discourse_parser_editor.gd
@@ -1,6 +1,6 @@
-class_name EditorDialogParser
-extends DialogParser
-## The [DialogParser] that NexusForge will use while its running in the editor.
+class_name NFEditorDialogParser
+extends NFDialogParser
+## The [NFDialogParser] that NexusForge will use while its running in the editor.
 ##
 ## The resources parsed by this object are [EditorDiscourseDialog] which
 ## contain a different structure from the released files.[br]
@@ -315,7 +315,7 @@ func _process_logic(uuid: StringName) -> Dictionary[String, Variant]:
 			var choices: Array[Dictionary] = []
 			
 			for choice:Dictionary in metadata["options"]:
-				var weight: int = DialogParser.RANDOM_DEFAULT_WEIGHT if choice["input_connections"]["weight"]["target_node_uuid"].is_empty() else _get_data(choice["input_connections"]["weight"]["target_node_uuid"])
+				var weight: int = NFDialogParser.RANDOM_DEFAULT_WEIGHT if choice["input_connections"]["weight"]["target_node_uuid"].is_empty() else _get_data(choice["input_connections"]["weight"]["target_node_uuid"])
 				if weight == 0:
 					continue
 				choices.append({

--- a/addons/nexus_forge/resources/quest_logger.gd
+++ b/addons/nexus_forge/resources/quest_logger.gd
@@ -20,7 +20,7 @@ func _get(property: StringName) -> Variant:
 
 
 ## Sets an entry on the log with [param id] and a [param success_status].
-func set_entry(id: StringName, success_status: QuestManager.SuccessStatus = QuestManager.SuccessStatus.UNKNOWN) -> NFQuestLogEntry:
+func set_entry(id: StringName, success_status: NFQuestManager.SuccessStatus = NFQuestManager.SuccessStatus.UNKNOWN) -> NFQuestLogEntry:
 	if _entries.has(id):
 		_entries[id].success_status = success_status
 	else:
@@ -32,11 +32,11 @@ func set_entry(id: StringName, success_status: QuestManager.SuccessStatus = Ques
 
 
 ## Returns the status of the quest with the provided [param id] or
-## [enum QuestManager.SuccessStatus.UNKNOWN] if the entry doesn't exist.
-func get_quest_status(id: StringName) -> QuestManager.SuccessStatus:
+## [enum NFQuestManager.SuccessStatus.UNKNOWN] if the entry doesn't exist.
+func get_quest_status(id: StringName) -> NFQuestManager.SuccessStatus:
 	if _entries.has(id):
 		return _entries[id].success_status
-	return QuestManager.SuccessStatus.UNKNOWN
+	return NFQuestManager.SuccessStatus.UNKNOWN
 
 
 ## Gets the quest log entry object with [param id].
@@ -104,7 +104,7 @@ func restore_state(data: Dictionary) -> void:
 		if (key_type != TYPE_STRING_NAME and key_type != TYPE_STRING) or typeof(data[key_entry]) != TYPE_DICTIONARY:
 			continue
 		
-		var status: QuestManager.SuccessStatus = QuestManager.SuccessStatus.UNKNOWN
+		var status: NFQuestManager.SuccessStatus = NFQuestManager.SuccessStatus.UNKNOWN
 		
 		if data[key_entry].has("success_status") and typeof(data[key_entry]["success_status"]) == TYPE_INT:
 			status = data[key_entry]["success_status"]
@@ -136,14 +136,14 @@ func clear() -> void:
 
 class NFQuestLogStatusEntry extends RefCounted:
 	## The status of the entry.
-	var success_status: QuestManager.SuccessStatus = QuestManager.SuccessStatus.UNKNOWN
+	var success_status: NFQuestManager.SuccessStatus = NFQuestManager.SuccessStatus.UNKNOWN
 	var _flags: int = 0:
 		set(f):
 			if _flags == 0:
 				_flags = f
 	
 	
-	func _init(status: QuestManager.SuccessStatus = QuestManager.SuccessStatus.UNKNOWN) -> void:
+	func _init(status: NFQuestManager.SuccessStatus = NFQuestManager.SuccessStatus.UNKNOWN) -> void:
 		success_status = status
 	
 	
@@ -161,7 +161,7 @@ class NFQuestLogEntry extends NFQuestLogStatusEntry:
 	var _entries: Dictionary[StringName, NFQuestLogStageEntry] = {}
 	
 	
-	func _init(entry_id: StringName = &"", status: QuestManager.SuccessStatus = QuestManager.SuccessStatus.UNKNOWN) -> void:
+	func _init(entry_id: StringName = &"", status: NFQuestManager.SuccessStatus = NFQuestManager.SuccessStatus.UNKNOWN) -> void:
 		id = entry_id
 		success_status = status
 	
@@ -183,7 +183,7 @@ class NFQuestLogEntry extends NFQuestLogStatusEntry:
 			if (key_type != TYPE_STRING_NAME and key_type != TYPE_STRING) or typeof(dict[key_entry]) != TYPE_DICTIONARY:
 				continue
 			
-			var success: QuestManager.SuccessStatus = QuestManager.SuccessStatus.UNKNOWN
+			var success: NFQuestManager.SuccessStatus = NFQuestManager.SuccessStatus.UNKNOWN
 			if dict[key_entry].has("success_status") and typeof(dict[key_entry]["success_status"]) == TYPE_INT:
 				success = dict[key_entry]["success_status"]
 			else:
@@ -208,7 +208,7 @@ class NFQuestLogEntry extends NFQuestLogStatusEntry:
 	
 	## Creates an entry with id [param stage_id] unless the entry already exists,
 	## in which [param status] is assigned to it.
-	func set_entry(stage_id: StringName, status: QuestManager.SuccessStatus = QuestManager.SuccessStatus.UNKNOWN) -> NFQuestLogStageEntry:
+	func set_entry(stage_id: StringName, status: NFQuestManager.SuccessStatus = NFQuestManager.SuccessStatus.UNKNOWN) -> NFQuestLogStageEntry:
 		if _entries.has(stage_id):
 			_entries[stage_id].success_status = status
 		else:
@@ -226,12 +226,12 @@ class NFQuestLogEntry extends NFQuestLogStatusEntry:
 		return null
 	
 	
-	## Returns the status of a stage or [enum QuestManager.SuccessStatus.UNKNOWN]
+	## Returns the status of a stage or [enum NFQuestManager.SuccessStatus.UNKNOWN]
 	## if the entry doesn't exist.
-	func get_status(entry_id: StringName) -> QuestManager.SuccessStatus:
+	func get_status(entry_id: StringName) -> NFQuestManager.SuccessStatus:
 		if _entries.has(entry_id):
 			return _entries[entry_id].success_status
-		return QuestManager.SuccessStatus.UNKNOWN
+		return NFQuestManager.SuccessStatus.UNKNOWN
 	
 	
 	## Returns the stage entries as a dictionary.
@@ -267,7 +267,7 @@ class NFQuestLogStageEntry extends NFQuestLogStatusEntry:
 	var _entries: Dictionary[StringName, NFQuestLogStatusEntry] = {}
 	
 	
-	func _init(entry_id: StringName = &"", status: QuestManager.SuccessStatus = QuestManager.SuccessStatus.UNKNOWN) -> void:
+	func _init(entry_id: StringName = &"", status: NFQuestManager.SuccessStatus = NFQuestManager.SuccessStatus.UNKNOWN) -> void:
 		id = entry_id
 		success_status = status
 	
@@ -295,7 +295,7 @@ class NFQuestLogStageEntry extends NFQuestLogStatusEntry:
 	
 	## Creates an entry with id [param objective_id] unless the entry already exists,
 	## in which [param status] is assigned to it.
-	func set_entry(objective_id: StringName, status: QuestManager.SuccessStatus = QuestManager.SuccessStatus.UNKNOWN) -> void:
+	func set_entry(objective_id: StringName, status: NFQuestManager.SuccessStatus = NFQuestManager.SuccessStatus.UNKNOWN) -> void:
 		if _entries.has(objective_id):
 			_entries[objective_id].success_status = status
 		else:
@@ -311,12 +311,12 @@ class NFQuestLogStageEntry extends NFQuestLogStatusEntry:
 		return null
 	
 	
-	## Returns the status of an objective or [enum QuestManager.SuccessStatus.UNKNOWN]
+	## Returns the status of an objective or [enum NFQuestManager.SuccessStatus.UNKNOWN]
 	## if the entry doesn't exist.
-	func get_status(objective_id: StringName) -> QuestManager.SuccessStatus:
+	func get_status(objective_id: StringName) -> NFQuestManager.SuccessStatus:
 		if _entries.has(objective_id):
 			return _entries[objective_id].success_status
-		return QuestManager.SuccessStatus.UNKNOWN
+		return NFQuestManager.SuccessStatus.UNKNOWN
 	
 	
 	## Returns the logged objectives data as a dictionary.

--- a/addons/nexus_forge/resources/quest_objective.gd
+++ b/addons/nexus_forge/resources/quest_objective.gd
@@ -4,128 +4,49 @@ class_name QuestObjective
 extends Resource
 
 
-enum ObjectiveType {}
+enum ObjectiveType {
+	TRAVEL = 0,
+	COLLECT = 1,
+}
+
+static var _regex_formatter: RegEx
 
 ## The ID of the objective.
 @export var id: StringName = &""
 ## The title of the objective.
-@export var title: String = "": set = _set_objective_title
+@export var title: String = "":
+	set(new_title):
+		if new_title == title:
+			return
+		title = new_title
+		if _title_builder.is_valid():
+			_title_builder = Callable()
 ## The description of the objective.
-@export var description: String = "": set = _set_objective_description
+@export var description: String = "":
+	set(new_desc):
+		if new_desc == description:
+			return
+		description = new_desc
+		if _description_builder.is_valid():
+			_description_builder = Callable()
 ## The objective type.
 @export var type: ObjectiveType
 ## Custom data assigned to this objective.
 @export var custom_data: Dictionary[String, Variant] = {}
 
-## Events emmited by the quest manager when the objective is successfully
-## completed.
-@export var on_success_events: Dictionary[String, Variant] = {}
-## Events emmited by the quest manager when the objective is failed.
-@export var on_failure_events: Dictionary[String, Variant] = {}
+## Dictionary containing the events signaled by the quest manager when the objective
+## completes. Currently only Succed and Failed are supported.
+@export var events: Dictionary[StringName, Dictionary] = {}
 
 @export var _requirements: Dictionary[String, Dictionary] = {}
 
-var _progress: Dictionary[String, Variant] = {}
-var _completed: bool = false
 var _title_builder: Callable = Callable()
 var _description_builder: Callable = Callable()
 
 
-func _get_default_value_of_type(type_id: int) -> Variant:
-	match type_id:
-		TYPE_BOOL:
-			return false
-		TYPE_INT:
-			return 0
-		TYPE_FLOAT:
-			return 0.0
-		TYPE_STRING:
-			return ""
-		TYPE_VECTOR2:
-			return Vector2.ZERO
-		TYPE_VECTOR2I:
-			return Vector2i.ZERO
-		TYPE_RECT2:
-			return Rect2()
-		TYPE_RECT2I:
-			return Rect2i()
-		TYPE_VECTOR3:
-			return Vector3.ZERO
-		TYPE_VECTOR3I:
-			return Vector3i.ZERO
-		TYPE_TRANSFORM2D:
-			return Transform2D()
-		TYPE_VECTOR4:
-			return Vector4.ZERO
-		TYPE_VECTOR4I:
-			return Vector4i.ZERO
-		TYPE_PLANE:
-			return Plane()
-		TYPE_QUATERNION:
-			return Quaternion()
-		TYPE_AABB:
-			return AABB()
-		TYPE_BASIS:
-			return Basis()
-		TYPE_TRANSFORM3D:
-			return Transform3D()
-		TYPE_PROJECTION:
-			return Projection()
-		TYPE_COLOR:
-			return Color()
-		TYPE_STRING_NAME:
-			return &""
-		TYPE_DICTIONARY:
-			return {}
-		TYPE_ARRAY:
-			return []
-		TYPE_PACKED_BYTE_ARRAY:
-			return PackedByteArray()
-		TYPE_PACKED_INT32_ARRAY:
-			return PackedInt32Array()
-		TYPE_PACKED_INT64_ARRAY:
-			return PackedInt64Array()
-		TYPE_PACKED_FLOAT32_ARRAY:
-			return PackedFloat32Array()
-		TYPE_PACKED_FLOAT64_ARRAY:
-			return PackedFloat64Array()
-		TYPE_PACKED_STRING_ARRAY:
-			return PackedStringArray()
-		TYPE_PACKED_VECTOR2_ARRAY:
-			return PackedVector2Array()
-		TYPE_PACKED_VECTOR3_ARRAY:
-			return PackedVector3Array()
-		TYPE_PACKED_COLOR_ARRAY:
-			return PackedColorArray()
-		TYPE_PACKED_VECTOR4_ARRAY:
-			return PackedVector4Array()
-		_:
-			return null
-
-
-func _set_objective_title(new_title: String) -> void:
-	if new_title == title:
-			return
-	title = new_title
-	if _title_builder.is_valid():
-		_title_builder = Callable()
-
-
-func _set_objective_description(new_desc: String) -> void:
-	if new_desc == description:
-		return
-	description = new_desc
-	if _description_builder.is_valid():
-		_description_builder = Callable()
-
-
-func _build_format(string: String, call_formats: Dictionary[String, Callable]) -> String:
-	var new_format: Dictionary[String, String] = {}
-	
-	for key in call_formats.keys():
-		new_format[key] = call_formats[key].call()
-	
-	return string.format(new_format)
+static func _static_init() -> void:
+	_regex_formatter = RegEx.new()
+	_regex_formatter.compile("\\{\\$[^\\}]+\\}")
 
 
 ## Returns the quest [member QuestObjective.title]. Formats it if [code]Format Quest Strings with Blackboard[/code]
@@ -137,17 +58,11 @@ func get_objective_title() -> String:
 	if _title_builder.is_valid():
 		return _title_builder.call()
 	
-	var _regex_formatter: RegEx
-	
-	_regex_formatter = RegEx.new()
-	_regex_formatter.compile("\\{\\$[^\\s\\}]+\\}")
-	
 	var title_formats: Dictionary[String, Callable] = {}
 	
 	for format_title in _regex_formatter.search_all(title):
 		var string_path: String = format_title.get_string().trim_prefix("{$").trim_suffix("}")
 		var path_simplified: String = string_path.simplify_path()
-		#var var_parts: PackedStringArray = string_path.rsplit("/", false, 1)
 		
 		var black_callable: Callable = NexusForge.Blackboard.get_variable.bind(path_simplified, path_simplified)
 		
@@ -161,26 +76,19 @@ func get_objective_title() -> String:
 ## Returns the quest [member QuestObjective.description]. Formats it if [code]Format Quest Strings with Blackboard[/code]
 ## is [code]On[/code] on [code]Project Settings[/code].
 func get_objective_description() -> String:
-	if not ProjectSettings.get_setting(NFPluginGameHandler.get_setting_path("items_format_strings"), false):
+	if not ProjectSettings.get_setting(NFPluginGameHandler.get_setting_path("quests_format_strings"), false):
 		return description
 	
 	if _description_builder.is_valid():
 		return _description_builder.call()
 	
-	var _regex_formatter: RegEx
-	
-	_regex_formatter = RegEx.new()
-	_regex_formatter.compile("\\{\\$[^\\s\\}]+\\}")
-	
 	var desc_formats: Dictionary[String, Callable] = {}
 	
 	for description_item in _regex_formatter.search_all(description):
 		var string_path: String = description_item.get_string().trim_prefix("{$").trim_suffix("}")
-		var var_parts: PackedStringArray = string_path.rsplit("/", false, 1)
-		if var_parts.size() != 2:
-			continue
+		var path_simplified: String = string_path.simplify_path()
 		
-		var variable: Callable = NexusForge.Blackboard.get_variable.bind(var_parts[0], var_parts[1], string_path)
+		var variable: Callable = NexusForge.Blackboard.get_variable.bind(path_simplified, path_simplified)
 		
 		desc_formats["$" + string_path] = variable
 	
@@ -226,84 +134,6 @@ func set_requirement(requirement_path: String, completion_operator: int, complet
 	_requirements[requirement_path] = {
 		"operator": completion_operator,
 		"value": completion_value}
-	if _progress.has(requirement_path) and typeof(_progress[requirement_path]) != get_requirement_type(requirement_path):
-		_progress.erase(requirement_path)
-
-
-## Sets the progress of [param requirement_path] to [param progress_value].[br]
-## [b]Important:[/b] The type of [param progress_value] must match the type of the
-## requirement otherwise the progress won't be set.
-func set_progress(requirement_path: String, progress_value) -> void:
-	if not _requirements.has(requirement_path) or typeof(_requirements[requirement_path]["value"]) != typeof(progress_value):
-		return
-	_progress[requirement_path] = progress_value
-
-
-## Returns a dicitionary with the progress for all requirements and their current mode.
-func get_objective_progress() -> Dictionary:
-	var progress: Dictionary = {}
-	
-	for req in _requirements.keys():
-		var current = null
-		if _progress.has(req):
-			current = _progress[req]
-		else:
-			current = _get_default_value_of_type(typeof(_requirements[req]["value"]))
-			
-		progress[req] = {
-				"mode": _requirements[req]["operator"],
-				"current": current,
-				"target": _requirements[req]["value"]}
-	
-	return progress
-
-
-## Returns the progress for the specific [param requirement]. Returns an empty
-## dictionary if [param requirement] isn't registered.
-func get_requirement_progress(requirement: String) -> Dictionary:
-	var progress: Dictionary = {}
-	if _requirements.has(requirement):
-		var current = null
-		if _progress.has(requirement):
-			current = _progress[requirement]
-		else:
-			current = _get_default_value_of_type(typeof(_requirements[requirement]["value"]))
-		progress["mode"] = _requirements[requirement]["operator"]
-		progress["current"] = current
-		progress["target"] = _requirements[requirement]["value"]
-	return progress
-
-
-func is_completed() -> bool:
-	return _completed
-
-
-## Returns [code]true[/code] if all the requirements in the objective have been
-## met and can be completed.
-func can_complete_objective() -> bool:
-	for requirement_path in _requirements.keys():
-		if not _progress.has(requirement_path):
-			return false
-		match _requirements[requirement_path]["operator"]:
-			OP_EQUAL:
-				if _progress[requirement_path] != _requirements[requirement_path]["value"]:
-					return false
-			OP_NOT_EQUAL:
-				if _progress[requirement_path] == _requirements[requirement_path]["value"]:
-					return false
-			OP_LESS:
-				if _requirements[requirement_path]["value"] <= _progress[requirement_path]:
-					return false
-			OP_LESS_EQUAL:
-				if _requirements[requirement_path]["value"] < _progress[requirement_path]:
-					return false
-			OP_GREATER:
-				if _progress[requirement_path] <= _requirements[requirement_path]["value"]:
-					return false
-			OP_GREATER_EQUAL:
-				if _progress[requirement_path] < _requirements[requirement_path]["value"]:
-					return false
-	return true
 
 
 ## Returns if the objective has the requirement with [param requirement_path].
@@ -311,13 +141,20 @@ func has_requirement(requirement_path: String) -> bool:
 	return _requirements.has(requirement_path)
 
 
+## Removes a specific requirement from the objective.
+func remove_requirement(requirement_path: String) -> void:
+	_requirements.erase(requirement_path)
+
+
 ## Clears all requirements from the objective.
 func clear_requirements() -> void:
 	_requirements.clear()
-	_progress.clear()
 
 
-## Forces the status of completed on the objective, even if the requirements
-## haven't been met.
-func set_completed(is_completed: bool) -> void:
-	_completed = is_completed
+func _build_format(string: String, call_formats: Dictionary[String, Callable]) -> String:
+	var new_format: Dictionary[String, String] = {}
+	
+	for key in call_formats:
+		new_format[key] = call_formats[key].call()
+	
+	return string.format(new_format)

--- a/addons/nexus_forge/resources/quest_objective.gd
+++ b/addons/nexus_forge/resources/quest_objective.gd
@@ -35,7 +35,7 @@ static var _regex_formatter: RegEx
 @export var custom_data: Dictionary[String, Variant] = {}
 
 ## Dictionary containing the events signaled by the quest manager when the objective
-## completes. Currently only Succed and Failed are supported.
+## completes. Currently only success and failure are supported.
 @export var events: Dictionary[StringName, Dictionary] = {}
 
 @export var _requirements: Dictionary[String, Dictionary] = {}

--- a/addons/nexus_forge/resources/quest_resource.gd
+++ b/addons/nexus_forge/resources/quest_resource.gd
@@ -41,7 +41,7 @@ static var _regex_formatter: RegEx
 ## successfully.
 
 ## Dictionary containing the events signaled by the quest manager when the quest
-## completes. Currently only Succed and Failed are supported.
+## completes. Currently only success and failure are supported.
 @export var events: Dictionary[StringName, Dictionary] = {}
 
 @export var _stages: Dictionary[StringName, QuestStage] = {}

--- a/addons/nexus_forge/resources/quest_resource.gd
+++ b/addons/nexus_forge/resources/quest_resource.gd
@@ -5,18 +5,32 @@ extends Resource
 
 
 enum QuestType {
-	MAIN_QUEST,
-	SIDE_QUEST
+	MAIN_QUEST = 0,
+	SIDE_QUEST = 1,
 }
+
+static var _regex_formatter: RegEx
 
 ## ID of the quest.
 @export var id: StringName = &""
 ## Type of the quest.
 @export var type: QuestType
 ## The title of the quest.
-@export var title: String = "": set = _set_quest_title
+@export var title: String = "":
+	set(new_title):
+		if new_title == title:
+			return
+		title = new_title
+		if _title_builder.is_valid():
+			_title_builder = Callable()
 ## The description of the quest.
-@export var description: String = "": set = _set_quest_description
+@export var description: String = "":
+	set(new_desc):
+		if new_desc == description:
+			return
+		description = new_desc
+		if _description_builder.is_valid():
+			_description_builder = Callable()
 ## Custom data assigned to the quest.
 @export var custom_data: Dictionary[String, Variant] = {}
 
@@ -25,15 +39,26 @@ enum QuestType {
 
 ## Events to be signaled by the [QuestManager] if the quest is completed
 ## successfully.
-@export var on_success_events: Dictionary[String, Variant] = {}
-## Events to be signaled by the [QuestManager] if the quest is failed.
-@export var on_failure_events: Dictionary[String, Variant] = {}
+
+## Dictionary containing the events signaled by the quest manager when the quest
+## completes. Currently only Succed and Failed are supported.
+@export var events: Dictionary[StringName, Dictionary] = {}
 
 @export var _stages: Dictionary[StringName, QuestStage] = {}
 
 var _title_builder: Callable = Callable()
 var _description_builder: Callable = Callable()
-var _mods_applied: bool = false
+var _mods_applied: bool = false:
+	set(a):
+		if _mods_applied:
+			return
+		_mods_applied = a
+
+
+static func _static_init() -> void:
+	_regex_formatter = RegEx.new()
+	_regex_formatter.compile("\\{\\$[^\\}]+\\}")
+
 
 ## Returns the quest [member Quest.title]. Formats it if [code]Format Quest Strings with Blackboard[/code]
 ## is [code]On[/code] on [code]Project Settings[/code].
@@ -44,20 +69,13 @@ func get_quest_title() -> String:
 	if _title_builder.is_valid():
 		return _title_builder.call()
 	
-	var _regex_formatter: RegEx
-	
-	_regex_formatter = RegEx.new()
-	_regex_formatter.compile("\\{\\$[^\\s\\}]+\\}")
-	
 	var title_formats: Dictionary[String, Callable] = {}
 	
 	for format_title in _regex_formatter.search_all(title):
 		var string_path: String = format_title.get_string().trim_prefix("{$").trim_suffix("}")
-		var var_parts: PackedStringArray = string_path.rsplit("/", false, 1)
-		if var_parts.size() != 2:
-			continue
+		var path_simplified: String = string_path.simplify_path()
 		
-		var variable: Callable = NexusForge.Blackboard.get_variable.bind(var_parts[0], var_parts[1], string_path)
+		var variable: Callable = NexusForge.Blackboard.get_variable.bind(path_simplified, path_simplified)
 		
 		title_formats["$" + string_path] = variable
 	
@@ -75,20 +93,13 @@ func get_quest_description() -> String:
 	if _description_builder.is_valid():
 		return _description_builder.call()
 	
-	var _regex_formatter: RegEx
-	
-	_regex_formatter = RegEx.new()
-	_regex_formatter.compile("\\{\\$[^\\s\\}]+\\}")
-	
 	var desc_formats: Dictionary = {}
 	
 	for description_item in _regex_formatter.search_all(description):
 		var string_path: String = description_item.get_string().trim_prefix("{$").trim_suffix("}")
-		var var_parts: PackedStringArray = string_path.rsplit("/", false, 1)
-		if var_parts.size() != 2:
-			continue
+		var path_simplified: String = string_path.simplify_path()
 		
-		var variable: Callable = NexusForge.Blackboard.get_variable.bind(var_parts[0], var_parts[1], string_path)
+		var variable: Callable = NexusForge.Blackboard.get_variable.bind(path_simplified, path_simplified)
 		
 		desc_formats["$" + string_path] = variable
 	
@@ -129,26 +140,10 @@ func get_stage(stage_id: StringName) -> QuestStage:
 	return null
 
 
-func _set_quest_title(new_title: String) -> void:
-	if new_title == title:
-			return
-	title = new_title
-	if _title_builder.is_valid():
-		_title_builder = Callable()
-
-
-func _set_quest_description(new_desc: String) -> void:
-	if new_desc == description:
-		return
-	description = new_desc
-	if _description_builder.is_valid():
-		_description_builder = Callable()
-
-
 func _build_format(string: String, call_formats: Dictionary[String, Callable]) -> String:
 	var new_format: Dictionary[String, String] = {}
 	
-	for key in call_formats.keys():
+	for key in call_formats:
 		new_format[key] = call_formats[key].call()
 	
 	return string.format(new_format)

--- a/addons/nexus_forge/resources/quest_stage.gd
+++ b/addons/nexus_forge/resources/quest_stage.gd
@@ -44,7 +44,7 @@ static var _regex_formatter: RegEx
 @export var failure_stage_id: StringName = &""
 
 ## Dictionary containing the events signaled by the quest manager when the stage
-## completes. Currently only Succed and Failed are supported.
+## completes. Currently only success and failure are supported.
 @export var events: Dictionary[StringName, Dictionary] = {}
 
 @export var _objectives: Dictionary[StringName, Dictionary] = {}

--- a/addons/nexus_forge/resources/quest_stage.gd
+++ b/addons/nexus_forge/resources/quest_stage.gd
@@ -5,14 +5,32 @@ extends Resource
 ## A resource representing a stage of a [Quest].
 
 
-enum StageType {}
+enum StageType {
+	DEFAULT = 0,
+	HIDDEN = 1,
+}
+
+
+static var _regex_formatter: RegEx
 
 ## The ID of the stage.
 @export var id: StringName = &""
 ## The title of the stage.
-@export var title: String = "": set = _set_stage_title
+@export var title: String = "":
+	set(new_title):
+		if new_title == title:
+			return
+		title = new_title
+		if _title_builder.is_valid():
+			_title_builder = Callable()
 ## The description of the stage.
-@export var description: String = "": set = _set_stage_description
+@export var description: String = "":
+	set(new_desc):
+		if new_desc == description:
+			return
+		description = new_desc
+		if _description_builder.is_valid():
+			_description_builder = Callable()
 ## The type of the stage.
 @export var type: StageType
 ## CUstom data assigned to the stage.
@@ -25,11 +43,9 @@ enum StageType {}
 ## signifies the end of the quest this is in.
 @export var failure_stage_id: StringName = &""
 
-## Events to be signaled by the [QuestManager] if the stage is completed
-## successfully.
-@export var on_success_events: Dictionary[String, Variant] = {}
-## Events to be signaled by the [QuestManager] if the stage is failed
-@export var on_failure_events: Dictionary[String, Variant] = {}
+## Dictionary containing the events signaled by the quest manager when the stage
+## completes. Currently only Succed and Failed are supported.
+@export var events: Dictionary[StringName, Dictionary] = {}
 
 @export var _objectives: Dictionary[StringName, Dictionary] = {}
 
@@ -37,29 +53,9 @@ var _title_builder: Callable = Callable()
 var _description_builder: Callable = Callable()
 
 
-func _set_stage_title(new_title: String) -> void:
-	if new_title == title:
-			return
-	title = new_title
-	if _title_builder.is_valid():
-		_title_builder = Callable()
-
-
-func _set_stage_description(new_desc: String) -> void:
-	if new_desc == description:
-		return
-	description = new_desc
-	if _description_builder.is_valid():
-		_description_builder = Callable()
-
-
-func _build_format(string: String, call_formats: Dictionary[String, Callable]) -> String:
-	var new_format: Dictionary[String, String] = {}
-	
-	for key in call_formats.keys():
-		new_format[key] = call_formats[key].call()
-	
-	return string.format(new_format)
+static func _static_init() -> void:
+	_regex_formatter = RegEx.new()
+	_regex_formatter.compile("\\{\\$[^\\}]+\\}")
 
 
 ## Returns the quest [member QuestStage.title]. Formats it if [code]Format Quest Strings with Blackboard[/code]
@@ -71,17 +67,11 @@ func get_stage_title() -> String:
 	if _title_builder.is_valid():
 		return _title_builder.call()
 	
-	var _regex_formatter: RegEx
-	
-	_regex_formatter = RegEx.new()
-	_regex_formatter.compile("\\{\\$[^\\s\\}]+\\}")
-	
 	var title_formats: Dictionary[String, Callable] = {}
 	
 	for format_title in _regex_formatter.search_all(title):
 		var string_path: String = format_title.get_string().trim_prefix("{$").trim_suffix("}")
 		var path_simplified: String = string_path.simplify_path()
-		#var var_parts: PackedStringArray = string_path.rsplit("/", false, 1)
 		
 		var black_callable: Callable = NexusForge.Blackboard.get_variable.bind(path_simplified, path_simplified)
 		
@@ -95,26 +85,19 @@ func get_stage_title() -> String:
 ## Returns the quest [member QuestStage.description]. Formats it if [code]Format Quest Strings with Blackboard[/code]
 ## is [code]On[/code] on [code]Project Settings[/code].
 func get_stage_description() -> String:
-	if not ProjectSettings.get_setting(NFPluginGameHandler.get_setting_path("items_format_strings"), false):
+	if not ProjectSettings.get_setting(NFPluginGameHandler.get_setting_path("quests_format_strings"), false):
 		return description
 	
 	if _description_builder.is_valid():
 		return _description_builder.call()
 	
-	var _regex_formatter: RegEx
-	
-	_regex_formatter = RegEx.new()
-	_regex_formatter.compile("\\{\\$[^\\s\\}]+\\}")
-	
 	var desc_formats: Dictionary[String, Callable] = {}
 	
 	for description_item in _regex_formatter.search_all(description):
 		var string_path: String = description_item.get_string().trim_prefix("{$").trim_suffix("}")
-		var var_parts: PackedStringArray = string_path.rsplit("/", false, 1)
-		if var_parts.size() != 2:
-			continue
+		var path_simplified: String = string_path.simplify_path()
 		
-		var variable: Callable = NexusForge.Blackboard.get_variable.bind(var_parts[0], var_parts[1], string_path)
+		var variable: Callable = NexusForge.Blackboard.get_variable.bind(path_simplified, path_simplified)
 		
 		desc_formats["$" + string_path] = variable
 	
@@ -166,17 +149,18 @@ func is_objective_required(objective_id: StringName) -> bool:
 	return false
 
 
-## Returns [code]true[/code] if all the required objectives have been completed.
-func can_complete_stage() -> bool:
-	for objective_id in _objectives:
-		if _objectives[objective_id]["required"] and not _objectives[objective_id]["objective"].is_completed():
-			return false
-	return true
-
-
 ## Returns the objective object assigned to [param objective_id]. Returns
 ## [code]null[/code] if the objective isn't registered.
 func get_objective(objective_id: StringName) -> QuestObjective:
 	if _objectives.has(objective_id):
 		return _objectives[objective_id]["objective"]
 	return null
+
+
+func _build_format(string: String, call_formats: Dictionary[String, Callable]) -> String:
+	var new_format: Dictionary[String, String] = {}
+	
+	for key in call_formats:
+		new_format[key] = call_formats[key].call()
+	
+	return string.format(new_format)

--- a/addons/nexus_forge/species/races_main_script.gd
+++ b/addons/nexus_forge/species/races_main_script.gd
@@ -1333,6 +1333,7 @@ func switch_to_species(species_id: StringName) -> void:
 
 func _notification(what: int) -> void:
 	if what == NOTIFICATION_PREDELETE:
-		if undo != null and is_instance_valid(undo):
+		if is_instance_valid(undo):
 			undo.clear_history()
 			undo.free()
+			undo = null

--- a/addons/nexus_forge/species/races_main_script.gd
+++ b/addons/nexus_forge/species/races_main_script.gd
@@ -213,7 +213,10 @@ func _do_set_race_description(species: StringName, new_description: String) -> v
 
 
 func _on_desc_text_focus_lost() -> void:
-	var old_desc: String = race_desc_txt_edt.get_meta(&"old_value", "")
+	if not race_desc_txt_edt.editable:
+		return
+	
+	var old_desc: String = race_desc_txt_edt.get_meta(&"old_value")
 	var new_desc: String = race_desc_txt_edt.text
 	
 	if new_desc == old_desc:

--- a/addons/nexus_forge/talents/talents_main_script.gd
+++ b/addons/nexus_forge/talents/talents_main_script.gd
@@ -1440,6 +1440,7 @@ func save() -> void:
 
 func _notification(what: int) -> void:
 	if what == NOTIFICATION_PREDELETE:
-		if undo != null and is_instance_valid(undo):
+		if is_instance_valid(undo):
 			undo.clear_history()
 			undo.free()
+			undo = null

--- a/addons/nexus_forge/talents/talents_main_script.gd
+++ b/addons/nexus_forge/talents/talents_main_script.gd
@@ -1231,6 +1231,9 @@ func _on_name_line_edit_toggled(toggled: bool, line: LineEdit, type: int) -> voi
 
 
 func _on_text_edit_focus_lost(text: TextEdit) -> void:
+	if not text.editable:
+		return
+	
 	var mode: int = 0
 	
 	if text == stat_desc_txt_edt:

--- a/addons/nexus_forge/variables/variables_main_script.gd
+++ b/addons/nexus_forge/variables/variables_main_script.gd
@@ -4,7 +4,7 @@ extends PanelContainer
 
 const UNDO_MAX_STEPS: int = 50
 
-var _variables_resource: BlackboardData = null
+var _variables_resource: NFBlackboardData = null
 var _switching_tree: bool = false
 var _current_folder: String = "":
 	set(new_tree):
@@ -138,8 +138,8 @@ func reload_resource(first_load: bool = false) -> void:
 	
 	if not res_path.is_empty() and ResourceLoader.exists(res_path):
 		var res_load: Resource = load(res_path)
-		if res_load is BlackboardData:
-			if res_load is BlackboardData:
+		if res_load is NFBlackboardData:
+			if res_load is NFBlackboardData:
 				_variables_resource = res_load
 	
 	if _variables_resource != null:
@@ -350,7 +350,7 @@ func on_create_resource_pressed() -> void:
 	var result = await new_dialog.dialog_finished
 	
 	if result[0]:
-		_variables_resource = BlackboardData.new()
+		_variables_resource = NFBlackboardData.new()
 		_variables_resource.resource_path = result[1]
 		ResourceSaver.save(_variables_resource, result[1])
 		ProjectSettings.set_setting(
@@ -389,7 +389,7 @@ func on_load_resource_pressed() -> void:
 	
 	if result[0]:
 		var res_pre: Resource = load(result[1])
-		if res_pre is BlackboardData:
+		if res_pre is NFBlackboardData:
 			_variables_resource = res_pre
 			ProjectSettings.set_setting(
 				NFPluginGameHandler.get_setting_path("variables"),

--- a/addons/nexus_forge/variables/variables_main_script.gd
+++ b/addons/nexus_forge/variables/variables_main_script.gd
@@ -667,6 +667,7 @@ func get_sorting_column() -> int:
 
 func _notification(what: int) -> void:
 	if what == NOTIFICATION_PREDELETE:
-		if undo != null and is_instance_valid(undo):
+		if is_instance_valid(undo):
+			undo.clear_history()
 			undo.free()
 			undo = null


### PR DESCRIPTION
Version seems stable.
Updates:
- Adds `UndoRedo` support for the quest system.
- Separated concerns between quest resources & quest tracking.
    - Quest resources now ONLY contain the data for the quest. All tracking methods were removed.
    - Quest tracking has been fully delegated to the quest manager.
- Renamed most object classes to have "NF" at the start.
- Improved quest serialisation & deserialisation for quests.
- Added support for "global" or static quest variables. These variables will be given to new quests when they are started and could progress them immediately.
- Fixed an issue affecting multiple modules where losing focus of a disable `TextEdit` would attempt to create an `UndoRedo` entry.
- Fixed several documentation typos.
- Updated the quest manager in-editor documentation to reflect all changes.
- Fixed quest title & description formatters not using the correct `ProjectSettings` setting.
- Fixed quests title & description formatters passing the wrong arguments to the blackboard.
- Fixed an export issue where an error was being printed for a null-access error when Godot was validating the Odyssey script.
- Fixed an error when exporting where it was instantiating the Discourse API object instead of getting the script classes.
- Added a bit more logging