### PR TITLE
V0.8.0 beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,6 @@
 > **Beta State:** The plugin is fully functional but some utility and navigation features are unimplemented, incomplete or inconsistent. Any breaking changes will be announced on the releases page. Please report any bugs you encounter!
 > 
 > This began as a personal tool, so it includes a few specific static helper classes tailored for my own workflow.
->
-> **About Undo/Redo:** Not all modules of Nexus Forge implement the Undo/Redo system. Check the roadmap to find out which modules support these actions.
 
 ## Contents
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Features that are planned to be implemented in the future:
 
 ### Beta & Beyond
 - [ ] **On Release:** Publish on Godot's Asset Library/Asset Store
-- [ ] **Core:** UndoRedo for all modules
+- [x] **Core:** UndoRedo for all modules
   - [x] Discourse (Dialogs)
   - [x] Blackboard (Variables)
   - [x] Persona (Characters)
@@ -106,7 +106,7 @@ Features that are planned to be implemented in the future:
   - [x] Depot (Items & Currencies)
   - [x] Blueprints (Recipes)
   - [x] Odyssey (Quests)
-  - [ ] Phrase Maps
+  - [x] Phrase Maps
 - [ ] **Core:** Implement an automatic mod loader
 - [ ] **Discourse:** Import/Export CSV files for localization
 - [ ] **Github Wiki:** Rewrite the Wiki and include examples using screenshots/gifs

--- a/addons/nexus_forge/characters/characters_main_script.gd
+++ b/addons/nexus_forge/characters/characters_main_script.gd
@@ -42,12 +42,7 @@ var exp_parser: Expression = null
 @onready var edit_genders_btn: Button = $CharacterContainer/BasicDataSplit/GeneralContainer/GenderContainer/EditGendersBtn
 
 
-func _ready() -> void:
-	set_process_input(false)
-
-
 func ready_plugin() -> void:
-	set_process_input(true)
 	exp_parser = Expression.new()
 	char_tree.ready_plugin()
 	character_data_tree.ready_plugin()
@@ -101,61 +96,36 @@ func ready_plugin() -> void:
 	edit_genders_btn.pressed.connect(_on_edit_genders_pressed)
 
 
-func _input(event: InputEvent) -> void:
-	if not is_visible_in_tree():
-		return
-	
-	var current_focus: Control = get_viewport().gui_get_focus_owner()
-	
-	if event is InputEventKey:
-		if event.echo or not event.pressed or not event.ctrl_pressed:
-			return
-		
-		if current_focus != null:
-			if current_focus is LineEdit:
-				if current_focus.is_editing():
-					return
-				elif current_focus is TextEdit:
-					return
-		
-		if event.keycode == KEY_Z:
-			if current_sheet == null:
-				get_viewport().set_input_as_handled()
-				return
-			
-			if event.shift_pressed:
-				if undo.has_redo():
-					var action_name: String = undo.get_action_name(undo.get_current_action() + 1)
-					undo.redo()
-					NFPluginGameHandler._log_msg(
-							"",
-							"Redo: " + action_name,
-							NFPluginGameHandler._LogLevel.EDITOR)
-					_something_changed()
-			else:
-				if undo.has_undo():
-					var action_name: String = undo.get_current_action_name()
-					undo.undo()
-					NFPluginGameHandler._log_msg(
-							"",
-							"Undo: " + action_name,
-							NFPluginGameHandler._LogLevel.EDITOR)
-					_something_changed()
-			get_viewport().set_input_as_handled()
-		elif event.keycode == KEY_Y:
-			if current_sheet == null:
-				get_viewport().set_input_as_handled()
-				return
-			
-			if undo.has_redo():
-				var action_name: String = undo.get_action_name(undo.get_current_action() + 1)
-				undo.redo()
-				NFPluginGameHandler._log_msg(
-						"",
-						"Redo: " + action_name,
-						NFPluginGameHandler._LogLevel.EDITOR)
-				_something_changed()
-			get_viewport().set_input_as_handled()
+func can_undo() -> bool:
+	if is_instance_valid(undo):
+		return undo.has_undo()
+	return false
+
+
+func can_redo() -> bool:
+	if is_instance_valid(undo):
+		return undo.has_redo()
+	return false
+
+
+func do_undo() -> void:
+	var action_name: String = undo.get_current_action_name()
+	undo.undo()
+	NFPluginGameHandler._log_msg(
+			"",
+			"Undo: " + action_name,
+			NFPluginGameHandler._LogLevel.EDITOR)
+	_something_changed()
+
+
+func do_redo() -> void:
+	var action_name: String = undo.get_action_name(undo.get_current_action() + 1)
+	undo.redo()
+	NFPluginGameHandler._log_msg(
+			"",
+			"Redo: " + action_name,
+			NFPluginGameHandler._LogLevel.EDITOR)
+	_something_changed()
 
 
 func _on_edit_genders_pressed() -> void:

--- a/addons/nexus_forge/depot/categories_container_script.gd
+++ b/addons/nexus_forge/depot/categories_container_script.gd
@@ -110,6 +110,7 @@ func _do_create_category(category_id: StringName, category_name: String, under: 
 				"depot - editor",
 				"Failed to create category '%s' on the editor." % category_id,
 				NFPluginGameHandler._LogLevel.ERROR)
+	_on_category_changed()
 
 
 func _undo_create_category(category_id: StringName) -> void:
@@ -121,15 +122,25 @@ func _undo_create_category(category_id: StringName) -> void:
 		add_cat_bool_btn.disabled = false
 		add_cat_str_btn.disabled = false
 		add_cat_fldr_btn.disabled = false
+	_on_category_changed()
 
 
 func add_data(data_key: String, data: Variant) -> void:
 	item_data_tree.add_data(data_key, data)
 	if item_data_tree.has_undo():
 		category_undo.create_action("Data Changed")
-		category_undo.add_do_method(item_data_tree.redo)
-		category_undo.add_undo_method(item_data_tree.undo)
+		category_undo.add_do_method(do_data_tree_undoredo.bind(false))
+		category_undo.add_undo_method(do_data_tree_undoredo.bind(true))
 		category_undo.commit_action(false)
+	_on_category_changed()
+
+
+func do_data_tree_undoredo(do_undo: bool) -> void:
+	if do_undo:
+		item_data_tree.undo()
+	else:
+		item_data_tree.redo()
+	_on_category_changed()
 
 
 func _on_category_selected(category_id: StringName) -> void:
@@ -247,6 +258,7 @@ func _do_erase_category(category_id: StringName, cats_to_erase: Array[StringName
 	for item_id in items_resource.items():
 		if cat_dict.has(items_resource.get_item_category(item_id)):
 			items_resource.set_item_category(item_id, &"")
+	_on_category_changed()
 
 
 func _undo_erase_category(parent_category: StringName, categories_snapshot: Dictionary[StringName, Dictionary], tree_snapshot: Dictionary[StringName, Dictionary], items_snapshot: Dictionary[StringName, StringName]) -> void:
@@ -257,6 +269,7 @@ func _undo_erase_category(parent_category: StringName, categories_snapshot: Dict
 	
 	for item_id in items_snapshot:
 		items_resource.set_item_category(item_id, items_snapshot[item_id])
+	_on_category_changed()
 
 
 func _on_category_name_changed(id: StringName, from: String, to: String) -> void:
@@ -274,6 +287,7 @@ func _do_rename_category(id: StringName, to: String) -> void:
 	if items_resource != null:
 		items_resource.set_category_name(id, to)
 	categories_tree.set_category_name(id, to)
+	_on_category_changed()
 
 
 func _on_category_id_changed(from: StringName, to: StringName) -> void:
@@ -302,6 +316,7 @@ func _do_update_category_id(from: StringName, to: StringName) -> void:
 			if items_resource.get_item_category(item_id) == from:
 				items_resource.set_item_category(item_id, to)
 	categories_tree.set_category_id(from, to)
+	_on_category_changed()
 	category_id_changed.emit(from, to)
 
 
@@ -319,6 +334,7 @@ func _do_move_category(category_id: String, new_parent: String) -> void:
 	if items_resource != null and items_resource.has_category(category_id):
 		items_resource.link_category(category_id, new_parent)
 	categories_tree.move_category(category_id, new_parent)
+	_on_category_changed()
 
 
 func _on_subcategory_created(category_id: StringName) -> void:
@@ -354,6 +370,7 @@ func _do_update_data_change(category_id: StringName, is_undo: bool) -> void:
 		item_data_tree.undo()
 	else:
 		item_data_tree.redo()
+	_on_category_changed()
 
 
 func save_current_category() -> void:

--- a/addons/nexus_forge/depot/depot_main_script.gd
+++ b/addons/nexus_forge/depot/depot_main_script.gd
@@ -39,58 +39,6 @@ func _input(event: InputEvent) -> void:
 				var category_id: StringName = categories_container.selected_category
 				categories_container._on_erase_category_pressed(category_id)
 			get_viewport().set_input_as_handled()
-			return
-		
-		if not event.ctrl_pressed:
-			return
-		
-		var current_focus: Control = get_viewport().gui_get_focus_owner()
-		
-		if current_focus != null:
-			if current_focus is LineEdit:
-				if current_focus.is_editing():
-					return
-			elif current_focus is TextEdit:
-				return
-		
-		var target_undo: UndoRedo = null
-		
-		if items_container.visible:
-			target_undo = items_container.undo
-		elif categories_container.visible:
-			target_undo = categories_container.category_undo
-		
-		if target_undo == null:
-			get_viewport().set_input_as_handled()
-			return
-		
-		if event.keycode == KEY_Z:
-			if event.shift_pressed:
-				if target_undo.has_redo():
-					var action_name: String = target_undo.get_action_name(target_undo.get_current_action() + 1)
-					target_undo.redo()
-					NFPluginGameHandler._log_msg(
-						"",
-						"Redo: " + action_name,
-						NFPluginGameHandler._LogLevel.EDITOR)
-			else:
-				if target_undo.has_undo():
-					var action_name: String = target_undo.get_current_action_name()
-					target_undo.undo()
-					NFPluginGameHandler._log_msg(
-						"",
-						"Undo: " + action_name,
-						NFPluginGameHandler._LogLevel.EDITOR)
-			get_viewport().set_input_as_handled()
-		elif event.keycode == KEY_Y and not event.shift_pressed:
-			if target_undo.has_redo():
-				var action_name: String = target_undo.get_action_name(target_undo.get_current_action() + 1)
-				target_undo.redo()
-				NFPluginGameHandler._log_msg(
-						"",
-						"Redo: " + action_name,
-						NFPluginGameHandler._LogLevel.EDITOR)
-			get_viewport().set_input_as_handled()
 
 
 func ready_plugin(use_items: bool, use_currencies: bool) -> void:
@@ -118,6 +66,48 @@ func ready_plugin(use_items: bool, use_currencies: bool) -> void:
 		edit_categories_btn.disabled = true
 	else:
 		_on_resource_loaded()
+
+
+func can_undo() -> bool:
+	if items_container.visible:
+		if is_instance_valid(items_container.undo):
+			return items_container.undo.has_undo()
+	elif categories_container.visible:
+		if is_instance_valid(categories_container.category_undo):
+			return categories_container.category_undo.has_undo()
+	return false
+
+
+func can_redo() -> bool:
+	if items_container.visible:
+		if is_instance_valid(items_container.undo):
+			return items_container.undo.has_redo()
+	elif categories_container.visible:
+		if is_instance_valid(categories_container.category_undo):
+			return categories_container.category_undo.has_redo()
+	return false
+
+
+func do_undo() -> void:
+	var is_items: bool = items_container.visible
+	var undo: UndoRedo = items_container.undo if is_items else categories_container.category_undo
+	var action_name: String = undo.get_action_name(undo.get_current_action() + 1)
+	undo.redo()
+	NFPluginGameHandler._log_msg(
+		"",
+		"Redo: " + action_name,
+		NFPluginGameHandler._LogLevel.EDITOR)
+
+
+func do_redo() -> void:
+	var is_items: bool = items_container.visible
+	var undo: UndoRedo = items_container.undo if is_items else categories_container.category_undo
+	var action_name: String = undo.get_action_name(undo.get_current_action() + 1)
+	undo.redo()
+	NFPluginGameHandler._log_msg(
+			"",
+			"Redo: " + action_name,
+			NFPluginGameHandler._LogLevel.EDITOR)
 
 
 func _on_category_id_updated(from: StringName, to: StringName) -> void:

--- a/addons/nexus_forge/depot/items_script.gd
+++ b/addons/nexus_forge/depot/items_script.gd
@@ -407,6 +407,7 @@ func _do_update_currency_value(currency_id: StringName, new_value: int) -> void:
 		switch_to_currency(currency_id)
 	currency_value_spn_bx.set_value_no_signal(new_value)
 	currency_value_spn_bx.set_meta(&"old_value", new_value)
+	_on_currency_changed()
 
 
 func _on_currency_deleted(currency_id: StringName) -> void:
@@ -456,6 +457,7 @@ func _undo_erase_currency(currency_id: StringName, currency_data: Dictionary) ->
 				"depot - editor",
 				"Couldn't restore currency '%s' on editor." % currency_id,
 				NFPluginGameHandler._LogLevel.ERROR)
+	_on_currency_changed()
 
 
 func _do_erase_currency(currency_id: StringName) -> void:
@@ -468,6 +470,7 @@ func _do_erase_currency(currency_id: StringName) -> void:
 		currency_value_spn_bx.set_value_no_signal(0)
 		currency_custom_data_tree.clear_data(false)
 		set_currency_ui_enabled(false)
+	_on_currency_changed()
 
 
 func _on_currency_id_changed(from: StringName, to: StringName) -> void:
@@ -491,6 +494,7 @@ func _do_change_currency_id(from: StringName, to: StringName) -> void:
 	if loaded_currency == from:
 		loaded_currency = to
 	currency_tree.change_currency_id(from, to)
+	_on_currency_changed()
 	
 
 
@@ -691,6 +695,7 @@ func _do_update_item_name(item_id: StringName, new_name: String) -> void:
 	item_name_ln_edt.text = new_name
 	item_name_ln_edt.set_meta(&"old_value", new_name)
 	item_link.item_renamed.emit(item_id, new_name)
+	_on_items_changed()
 
 
 func _on_currency_name_edit_toggled(is_toggled: bool) -> void:
@@ -719,6 +724,7 @@ func _do_rename_currency(currency_id: StringName, new_name: String) -> void:
 	
 	currency_name_ln_edt.text = new_name
 	currency_name_ln_edt.set_meta(&"old_value", new_name)
+	_on_currency_changed()
 
 
 func _on_item_description_focus_exited() -> void:
@@ -747,6 +753,7 @@ func _do_update_description(item_id: StringName, new_desc: String) -> void:
 		items_tree.select_item(item_id, false)
 	item_desc_txt_edt.text = new_desc
 	item_desc_txt_edt.set_meta(&"old_value", new_desc)
+	_on_items_changed()
 
 
 func _on_new_category_selected(idx: int) -> void:
@@ -776,6 +783,7 @@ func _do_update_category(item_id: StringName, category: StringName) -> void:
 				"depot - editor",
 				"Tried to undo select to a non-existing category '%s'. Selecting (uncategorized)" % category,
 				NFPluginGameHandler._LogLevel.EDITOR)
+	_on_items_changed()
 
 
 func _on_rarity_selected(idx: int) -> void:
@@ -800,6 +808,7 @@ func _do_update_rarity(item_id: StringName, rarity: int) -> void:
 		switch_to_item(item_id)
 		items_tree.select_item(item_id, false)
 	select_rarity(rarity)
+	_on_items_changed()
 
 
 func _on_item_value_changed(new_value: int) -> void:
@@ -821,6 +830,7 @@ func _do_update_item_value(item_id: StringName, new_value: int) -> void:
 		items_tree.select_item(item_id, false)
 	item_val_spn_bx.set_value_no_signal(new_value)
 	item_val_spn_bx.set_meta(&"old_value", new_value)
+	_on_items_changed()
 
 
 func _on_item_data_changed() -> void:
@@ -841,6 +851,7 @@ func _do_update_item_data(item_id: StringName, is_undo: bool) -> void:
 		item_data_tree.undo()
 	else:
 		item_data_tree.redo()
+	_on_items_changed()
 
 
 func _on_item_id_changed(from: StringName, to: StringName) -> void:
@@ -1017,6 +1028,7 @@ func _do_erase_item(item_id: StringName) -> void:
 		set_items_ui_enabled(false)
 	
 	update_page_label()
+	_on_items_changed()
 	item_deleted.emit(item_id)
 
 
@@ -1025,6 +1037,7 @@ func _undo_erase_item(item_id: StringName, item_data: Dictionary[String, Variant
 	item_link.create_item(item_id)
 	item_link.set_item_name(item_id, item_data["name"])
 	item_link.items._items[item_id] = item_data.duplicate(true)
+	_on_items_changed()
 
 
 func _on_create_item_pressed() -> void:
@@ -1328,6 +1341,7 @@ func _do_update_currency_data(currency_id: StringName, is_undo: bool) -> void:
 		currency_custom_data_tree.undo()
 	else:
 		currency_custom_data_tree.redo()
+	_on_currency_changed()
 
 
 func _on_items_changed(arg = null) -> void:
@@ -1373,6 +1387,7 @@ func _do_update_flag_toggled(flag_id: String, set_pressed: bool) -> void:
 		if item.get_meta(&"flag_id") != flag_id:
 			continue
 		item.set_pressed_no_signal(set_pressed)
+		_on_items_changed()
 		return
 	
 	NFPluginGameHandler._log_msg(

--- a/addons/nexus_forge/discourse/discourse_main_panel_script.gd
+++ b/addons/nexus_forge/discourse/discourse_main_panel_script.gd
@@ -128,61 +128,7 @@ var _recently_opened_popup: PopupMenu = null
 @onready var auto_update_previewer: Button = $LocalizationContainer/MainSplitContainer/LeftSplitContainer/LocaleContainer/LocalePanel/DialogScenePreviewer/HBoxContainer/ButtonContaienr/AutoUpdateBtn
 
 
-func _ready() -> void:
-	set_process_input(false)
-
-
-func _input(event: InputEvent) -> void:
-	if not is_visible_in_tree() or undo == null:
-		return
-	
-	if event is InputEventKey:
-		if event.echo or not event.pressed or not event.ctrl_pressed:
-			return
-		
-		var current_focus: Control = get_viewport().gui_get_focus_owner()
-		
-		if current_focus != null:
-			if current_focus is LineEdit:
-				if current_focus.is_editing():
-					return
-			elif current_focus is TextEdit:
-				return
-		
-		if event.keycode == KEY_Z:
-			if event.shift_pressed:
-				if undo.has_redo():
-					var action_name: String = undo.get_action_name(undo.get_current_action() + 1)
-					undo.redo()
-					NFPluginGameHandler._log_msg(
-						"",
-						"Redo: " + action_name,
-						NFPluginGameHandler._LogLevel.EDITOR)
-					_on_conversation_changed()
-			else:
-				if undo.has_undo():
-					var action_name: String = undo.get_current_action_name()
-					undo.undo()
-					NFPluginGameHandler._log_msg(
-						"",
-						"Undo: " + action_name,
-						NFPluginGameHandler._LogLevel.EDITOR)
-					_on_conversation_changed()
-			get_viewport().set_input_as_handled()
-		elif event.keycode == KEY_Y and not event.shift_pressed:
-			if undo.has_redo():
-				var action_name: String = undo.get_action_name(undo.get_current_action() + 1)
-				undo.redo()
-				NFPluginGameHandler._log_msg(
-					"",
-					"Redo: " + action_name,
-					NFPluginGameHandler._LogLevel.EDITOR)
-				_on_conversation_changed()
-			get_viewport().set_input_as_handled()
-
-
 func ready_plugin(base_locale: String = "") -> void:
-	set_process_input(true)
 	text_editor = TEXT_CODE_EDITOR.instantiate()
 	add_child(text_editor)
 	text_editor.ready_plugin()
@@ -609,6 +555,38 @@ func ready_plugin(base_locale: String = "") -> void:
 	
 	discourse_graph_edit.travel_node_target_id_changed.connect(_on_travel_node_target_id_changed)
 	discourse_graph_edit.travel_node_selected_waypoint_changed.connect(_on_travel_node_selected_waypoint_changed)
+
+
+func can_undo() -> bool:
+	if is_instance_valid(undo):
+		return undo.has_undo()
+	return false
+
+
+func can_redo() -> bool:
+	if is_instance_valid(undo):
+		return undo.has_redo()
+	return false
+
+
+func do_undo() -> void:
+	var action_name: String = undo.get_current_action_name()
+	undo.undo()
+	NFPluginGameHandler._log_msg(
+		"",
+		"Undo: " + action_name,
+		NFPluginGameHandler._LogLevel.EDITOR)
+	_on_conversation_changed()
+
+
+func do_redo() -> void:
+	var action_name: String = undo.get_action_name(undo.get_current_action() + 1)
+	undo.redo()
+	NFPluginGameHandler._log_msg(
+		"",
+		"Redo: " + action_name,
+		NFPluginGameHandler._LogLevel.EDITOR)
+	_on_conversation_changed()
 
 
 func get_column_left() -> Control:

--- a/addons/nexus_forge/discourse/discourse_main_panel_script.gd
+++ b/addons/nexus_forge/discourse/discourse_main_panel_script.gd
@@ -2681,13 +2681,58 @@ func _on_case_search_text_changed(text: String) -> void:
 
 
 func _on_new_case_button_pressed() -> void:
-	create_new_phrase_case()
+	var phrase_key: String = %PhrasesEntries.get_child(selected_phrase_index).get_meta(&"phrase_key")
+	var selected_format: String = argument_opt_btn.get_item_text(argument_opt_btn.selected)
+	var case_locale: String = phrases_lang_menu.get_selected_metadata()
+	var case_key: String = get_valid_phrase_case_key("case")
+	
+	undo.create_action("Create Case on '%s' format '%s' (%s)" % [phrase_key, selected_format, case_locale])
+	undo.add_do_method(_do_create_case.bind(phrase_key, selected_format, case_locale, case_key, ""))
+	undo.add_undo_method(_undo_create_case.bind(phrase_key, selected_format, case_locale, case_key))
+	undo.commit_action()
+	
 	_on_conversation_changed()
 
 
-func _on_erase_case_button_pressed(case_line: Control) -> void:
-	erase_case(case_line.get_index())
-	_on_case_line_text_changed()
+func _on_erase_case_button_pressed(case_container: Control) -> void:
+	var case_line: LineEdit = case_container.get_child(1)
+	var selected_format: String = argument_opt_btn.get_item_text(argument_opt_btn.selected)
+	var phrase_key: String = %PhrasesEntries.get_child(selected_phrase_index).get_meta(&"phrase_key")
+	var case_result: String = case_container.get_child(2).text
+	var case_locale: String = phrases_lang_menu.get_selected_metadata()
+	
+	undo.create_action("Erase Case on '%s' format '%s' (%s)" % [phrase_key, selected_format, case_locale])
+	undo.add_do_method(_undo_create_case.bind(phrase_key, selected_format, case_locale, case_line.text))
+	undo.add_undo_method(_do_create_case.bind(phrase_key, selected_format, case_locale, case_line.text, case_result))
+	undo.commit_action()
+	
+	_on_conversation_changed()
+
+
+func _do_create_case(phrase_key: String, on_format: String, on_locale: String, case_key: String, case_result: String) -> void:
+	active_conversation.set_format_string_case(
+			phrase_key,
+			on_locale,
+			on_format,
+			case_key,
+			case_result)
+	
+	if 0 <= selected_phrase_index and %PhrasesEntries.get_child(selected_phrase_index).get_meta(&"phrase_key") == phrase_key and\
+			0 < argument_opt_btn.item_count and argument_opt_btn.get_item_text(argument_opt_btn.selected) == on_format and\
+			0 < phrases_lang_menu.item_count and phrases_lang_menu.get_selected_metadata() == on_locale:
+		create_new_phrase_case(case_key, case_result)
+
+
+func _undo_create_case(phrase_key: String, on_format: String, on_locale: String, case_key: String) -> void:
+	active_conversation.erase_format_string_case(phrase_key, on_locale, on_format, case_key)
+	if 0 <= selected_phrase_index and %PhrasesEntries.get_child(selected_phrase_index).get_meta(&"phrase_key") == phrase_key and\
+			0 < argument_opt_btn.item_count and argument_opt_btn.get_item_text(argument_opt_btn.selected) == on_format and\
+			0 < phrases_lang_menu.item_count and phrases_lang_menu.get_selected_metadata() == on_locale:
+		for case_idx in range(1, %PhraseCasesEntries.get_child_count()):
+			var case_container: Control = %PhraseCasesEntries.get_child(case_idx)
+			if case_container.get_child(1).get_meta(&"old_value") == case_key:
+				erase_case(case_idx)
+				return
 
 
 func _on_open_phrase_case_text_editor_pressed(target: TextEdit) -> void:
@@ -2827,36 +2872,36 @@ func set_text_code_editor_variable_paths(paths: Array[Dictionary]) -> void:
 
 
 func _on_case_line_text_changed(_text: String = "") -> void:
-	_validate_phrase_cases()
 	_on_conversation_changed()
 
 
-func _validate_phrase_cases() -> void:
-	var all_ids: Dictionary[String, Array] = {}
+func get_valid_phrase_case_key(desired_id: String, ignore_line: LineEdit = null) -> String:
+	var all_ids: Dictionary[String, Variant] = {}
 	
 	for case_idx in range(1, %PhraseCasesEntries.get_child_count()):
 		var case: HBoxContainer = %PhraseCasesEntries.get_child(case_idx)
 		if case.is_queued_for_deletion():
 			continue
-		
 		var item: LineEdit = case.get_child(1)
-		var key: String = item.text.strip_edges()
-		
-		if key.is_empty():
+		if item == ignore_line:
 			continue
-		
-		if not all_ids.has(key):
-			all_ids[key] = []
-		all_ids[key].append(item)
+		all_ids[item.text] = null
 	
-	for item_key:String in all_ids.keys():
-		if 1 < all_ids[item_key].size():
-			for item:LineEdit in all_ids[item_key]:
-				item.add_theme_color_override(&"font_color", Color(1.0, 0.29, 0.325))
-		else:
-			for item:LineEdit in all_ids[item_key]:
-				if item.has_theme_color(&"font_color"):
-					item.remove_theme_color_override(&"font_color")
+	if not all_ids.has(desired_id):
+		return desired_id
+	
+	var modified: String = desired_id.strip_edges()
+	var base: String = modified
+	var iteration_data: Dictionary = StringUtils.get_trailing_integer(modified)
+	var iteration: int = iteration_data["integer"]
+	if iteration_data["has_integer"]:
+		base = base.trim_suffix(str(iteration))
+	
+	while all_ids.has(modified):
+		iteration += 1
+		modified = base + str(iteration)
+	
+	return modified
 
 
 func _on_text_line_text_submitted(_text: String, edit_btn: Button) -> void:
@@ -2950,27 +2995,72 @@ func _on_key_line_text_changed(_text: String = "") -> void:
 	_on_conversation_changed()
 
 
+func _on_new_key_field_button_pressed() -> void:
+	var valid_id: String = get_valid_format_key_id("NEW_PHRASE")
+	
+	undo.create_action("Create Phrase")
+	undo.add_do_method(_do_create_phrase_entry.bind(valid_id, "", phrases_lang_menu.get_selected_metadata()))
+	undo.add_undo_method(_undo_create_phrase_entry.bind(valid_id))
+	undo.commit_action()
+	
+	_on_conversation_changed()
+
+
 func _on_erase_key_button_pressed(field: HBoxContainer) -> void:
 	var phrase_key: String = field.get_meta(&"phrase_key")
-	if selected_phrase_index == field.get_index():
-		selected_phrase_index = -1
-		clear_cases()
-		default_case_edt.clear()
-		default_case_edt.editable = false
-		argument_opt_btn.clear()
-		argument_opt_btn.disabled = true
-		new_case_btn.disabled = true
+	var locale: String = phrases_lang_menu.get_selected_metadata()
+	var data: Dictionary = active_conversation.format_strings.get(phrase_key, {}).duplicate(true)
+	var current_text: String = active_conversation.get_format_string(phrase_key, locale)
 	
-	active_conversation.format_strings.erase(phrase_key)
+	undo.create_action("Erase Phrase")
+	undo.add_do_method(_undo_create_phrase_entry.bind(phrase_key))
+	undo.add_undo_method(_do_create_phrase_entry.bind(phrase_key, current_text, locale, data))
+	undo.commit_action()
 	
-	erase_key(field.get_index())
-	
-	_on_key_line_text_changed()
-
-
-func _on_new_key_field_button_pressed() -> void:
-	create_new_phrase_entry(&"", "")
 	_on_conversation_changed()
+
+
+func _do_create_phrase_entry(key: String, text: String, locale: String, data: Dictionary = {}) -> void:
+	if data.is_empty():
+		active_conversation.set_format_string(key, text, locale)
+		create_new_phrase_entry(key, text)
+	else:
+		active_conversation[key] = data.duplicate(true)
+		if 0 < phrases_lang_menu.item_count:
+			create_new_phrase_entry(
+					key,
+					active_conversation.get_format_string(
+							key,
+							phrases_lang_menu.get_selected_metadata()))
+
+
+func _undo_create_phrase_entry(key: String) -> void:
+	active_conversation.format_strings.erase(key)
+	var erase_target: int = -1
+	var new_selected: int = selected_phrase_index
+	
+	for item in %PhrasesEntries.get_children():
+		erase_target += 1
+		if item.get_meta(&"phrase_key") == key:
+			break
+	
+	if erase_target < 0:
+		return
+	
+	var current_selected: Control = null
+	if 0 <= selected_phrase_index:
+		if selected_phrase_index == erase_target:
+			selected_phrase_index = -1
+			clear_cases()
+			default_case_edt.clear()
+			default_case_edt.editable = false
+			argument_opt_btn.clear()
+			argument_opt_btn.disabled = true
+			new_case_btn.disabled = true
+		elif erase_target < selected_phrase_index:
+			selected_phrase_index -= 1
+	
+	erase_key(erase_target)
 
 
 func _rebuild_phrase_text_menu(text_menu: PopupMenu) -> void:
@@ -3100,6 +3190,7 @@ func create_new_phrase_case(case: String = "", case_text: String = "") -> void:
 	var case_editor: TextEdit = BracketHandler.new()
 	var expand_case: Button = Button.new()
 	var highlighter: NFEditorDialogSyntaxHighlighter = NFEditorDialogSyntaxHighlighter.new()
+	var valid_id: String = get_valid_phrase_case_key(case)
 	
 	highlighter.set_use_token("*", false)
 	highlighter.set_use_token("?", false)
@@ -3130,11 +3221,11 @@ func create_new_phrase_case(case: String = "", case_text: String = "") -> void:
 	
 	case_line.placeholder_text = "Case"
 	case_line.custom_minimum_size.y = 33.0
-	case_line.text = case
+	case_line.text = valid_id
 	case_line.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	case_line.size_flags_vertical = Control.SIZE_SHRINK_CENTER
 	case_line.size_flags_stretch_ratio = 1.0
-	case_line.set_meta(&"old_value", case)
+	case_line.set_meta(&"old_value", valid_id)
 	
 	case_container.add_child(erase_case_btn)
 	case_container.add_child(case_line)
@@ -3157,10 +3248,10 @@ func create_new_phrase_case(case: String = "", case_text: String = "") -> void:
 		default_case_edt.focus_next = case_line.get_path()
 	
 	case_line.text_changed.connect(_on_case_line_text_changed)
+	case_line.editing_toggled.connect(_on_phrase_case_editing_toggled.bind(case_line))
+	
 	case_editor.text_changed.connect(_on_phrase_text_field_changed.bind(case_editor))
 	case_editor.resized.connect(_update_choice_textbox_size.bind(case_editor))
-	
-	case_line.editing_toggled.connect(_on_phrase_case_editing_toggled.bind(case_line))
 	case_editor.focus_exited.connect(_on_phrase_case_result_focus_exited.bind(case_editor))
 
 
@@ -3179,11 +3270,12 @@ func erase_case(index: int) -> void:
 		new_case_btn.focus_next = ^""
 	else:
 		if index == 1: # It's the first item
-			var target_ln: LineEdit = %PhraseCasesEntries.get_child(1)
+			var target_child: Control = %PhraseCasesEntries.get_child(1)
+			var target_ln: LineEdit = target_child.get_child(1)
 			new_text_button.focus_next = target_ln.get_path()
 			target_ln.focus_previous = new_text_button.get_path()
 		elif new_case_count == index: # It's the last item
-			var target_text: LineEdit = %PhraseCasesEntries.get_child(-2).get_child(3)
+			var target_text: Button = %PhraseCasesEntries.get_child(-2).get_child(3)
 			target_text.focus_next = ^""
 		else: # It's between 2 items
 			var btn_up: Button = %PhraseCasesEntries.get_child(index - 1).get_child(3)
@@ -3201,6 +3293,7 @@ func create_new_phrase_entry(key: String, format: String, unsaved: bool = true) 
 	var text_field: TextEdit = BracketHandler.new()
 	var edit_button: Button = Button.new()
 	var highlighter: NFEditorDialogSyntaxHighlighter = NFEditorDialogSyntaxHighlighter.new()
+	var valid_key: String = get_valid_format_key_id(key)
 	
 	highlighter.set_use_token("&", false)
 	highlighter.set_use_token("*", false)
@@ -3208,21 +3301,15 @@ func create_new_phrase_entry(key: String, format: String, unsaved: bool = true) 
 	
 	text_field.syntax_highlighter = highlighter
 	
-	if key.is_empty():
-		key = get_valid_format_key_id(key)
-	else:
-		key = get_valid_format_key_id(key)
-	
 	container.set_meta(&"entry_id", UUID.generate_new())
-	container.set_meta(&"phrase_key", key)
-	container.set_meta(&"unsaved", unsaved)
+	container.set_meta(&"phrase_key", valid_key)
 	container.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	
 	key_line.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	key_line.size_flags_vertical = Control.SIZE_SHRINK_CENTER
 	key_line.custom_minimum_size = Vector2(115.0, 33.0)
 	key_line.placeholder_text = "Key"
-	key_line.text = String(key)
+	key_line.text = valid_key
 	key_line.set_meta(&"old_value", key_line.text)
 	
 	erase_button.icon = get_theme_icon("Remove", "EditorIcons")
@@ -3283,7 +3370,7 @@ func create_new_phrase_entry(key: String, format: String, unsaved: bool = true) 
 	key_line.text_changed.connect(_on_key_line_text_changed)
 	erase_button.pressed.connect(_on_erase_key_button_pressed.bind(container))
 	
-	return key
+	return valid_key
 
 
 func erase_key(index: int) -> void:
@@ -3365,8 +3452,6 @@ func save_current_phrase_key(locale_code: String, format: String) -> void:
 			format,
 			modified,
 			case_container.get_child(2).text)
-	
-	_validate_phrase_cases()
 
 
 func save_phrase_keys(locale: String) -> void:
@@ -3399,9 +3484,7 @@ func save_phrase_keys(locale: String) -> void:
 		var new_key: String = modified
 		claimed_keys[new_key] = null
 		
-		if entry.get_meta(&"unsaved"):
-			entry.set_meta(&"unsaved", false)
-		elif new_key != old_key:
+		if new_key != old_key:
 			active_conversation.format_strings[new_key] = active_conversation.format_strings[old_key]
 			active_conversation.format_strings.erase(old_key)
 		
@@ -3906,6 +3989,8 @@ func _on_phrase_key_editing_toggled(is_toggled: bool, line: LineEdit) -> void:
 	var old_value: String = line.get_parent().get_meta(&"phrase_key")
 	
 	if new_value == old_value:
+		if line.text != new_value:
+			line.text = new_value
 		return
 	
 	undo.create_action("Set Phrase Key")
@@ -4053,9 +4138,11 @@ func _on_phrase_case_editing_toggled(is_toggled: bool, case_line: LineEdit) -> v
 		return
 	
 	var old_case: String = case_line.get_meta(&"old_value")
-	var new_case: String = case_line.text
+	var new_case: String = get_valid_phrase_case_key(case_line.text, case_line)
 	
 	if new_case == old_case:
+		if case_line.text != new_case:
+			case_line.text = new_case
 		return
 	
 	var key: String = %PhrasesEntries.get_child(selected_phrase_index).get_meta(&"phrase_key")

--- a/addons/nexus_forge/nexus_forge_main_scene_script.gd
+++ b/addons/nexus_forge/nexus_forge_main_scene_script.gd
@@ -9,7 +9,6 @@ var tool_count: int = 0
 @onready var tool_container: PanelContainer = $MainContainer/ToolScroll/ToolContainer
 @onready var tool_tab_bar: TabBar = $MainContainer/ToolTabBar
 @onready var splash_texture: TextureRect = $MainContainer/ToolScroll/ToolContainer/NexusForge/SplashPanel/SplashTexture
-#@onready var reload_image_btn: Button = $MainContainer/ToolContainer/NexusForge/SplashPanel/SplashTexture/ReloadImageBtn
 # ----- Tools -----
 var discourse: PanelContainer = null
 var variables: PanelContainer = null
@@ -61,7 +60,8 @@ func _input(event: InputEvent) -> void:
 					if focused_node.is_editing():
 						return
 				elif focused_node is TextEdit:
-					return
+					if focused_node.editable:
+						return
 			if 0 < tool_tab_bar.current_tab:
 				var target: Control = tool_container.get_child(current_tab)
 				if event.shift_pressed:

--- a/addons/nexus_forge/nexus_forge_main_scene_script.gd
+++ b/addons/nexus_forge/nexus_forge_main_scene_script.gd
@@ -5,6 +5,7 @@ extends Control
 var recipes_link: EditorItemRecipeLink = EditorItemRecipeLink.new()
 var current_tab: int = 0
 var tool_count: int = 0
+
 @onready var tool_container: PanelContainer = $MainContainer/ToolScroll/ToolContainer
 @onready var tool_tab_bar: TabBar = $MainContainer/ToolTabBar
 @onready var splash_texture: TextureRect = $MainContainer/ToolScroll/ToolContainer/NexusForge/SplashPanel/SplashTexture
@@ -25,6 +26,64 @@ var phrase_maps: PanelContainer = null
 
 func set_version(version: String) -> void:
 	$MainContainer/ToolScroll/ToolContainer/NexusForge/VersionLabel.text = version
+
+
+func _input(event: InputEvent) -> void:
+	if not is_visible_in_tree():
+		return
+	
+	if event is InputEventKey:
+		if not event.is_pressed() or event.is_echo():
+			return
+		
+		if event.keycode == KEY_TAB:
+			if event.ctrl_pressed:
+				if  event.shift_pressed:
+					tool_tab_bar.current_tab = posmod(tool_tab_bar.current_tab - 1, tool_count)
+				else:
+					tool_tab_bar.current_tab = posmod(tool_tab_bar.current_tab + 1, tool_count)
+				get_viewport().set_input_as_handled()
+		elif event.keycode == KEY_W:
+			if event.ctrl_pressed:
+				if discourse != null and discourse.visible:
+					discourse.close_active_conversation()
+					get_viewport().set_input_as_handled()
+				elif characters != null and characters.visible:
+					characters.close_active_character()
+					get_viewport().set_input_as_handled()
+				elif phrase_maps != null and phrase_maps.visible:
+					phrase_maps.close_active_map()
+					get_viewport().set_input_as_handled()
+		elif event.ctrl_pressed and event.keycode == KEY_Z:
+			var focused_node: Control = get_viewport().gui_get_focus_owner()
+			if focused_node != null:
+				if focused_node is LineEdit:
+					if focused_node.is_editing():
+						return
+				elif focused_node is TextEdit:
+					return
+			if 0 < tool_tab_bar.current_tab:
+				var target: Control = tool_container.get_child(current_tab)
+				if event.shift_pressed:
+					if target.can_redo():
+						target.do_redo()
+				else:
+					if target.can_undo():
+						target.do_undo()
+			get_viewport().set_input_as_handled()
+		elif event.ctrl_pressed and not event.shift_pressed and event.keycode == KEY_Y:
+			var focused_node: Control = get_viewport().gui_get_focus_owner()
+			if focused_node != null:
+				if focused_node is LineEdit:
+					if focused_node.is_editing():
+						return
+				elif focused_node is TextEdit:
+					return
+			if 0 < tool_tab_bar.current_tab:
+				var target: Control = tool_container.get_child(current_tab)
+				if target.can_redo():
+					target.do_redo()
+			get_viewport().set_input_as_handled()
 
 
 func ready_plugin(use_discourse: bool, use_characters: bool, use_species: bool, use_stats: bool, use_skills: bool, use_traits: bool, use_items: bool, use_currencies: bool, use_recipes: bool, use_quests: bool, use_phrases: bool, discourse_base_lang: String) -> void:
@@ -193,30 +252,6 @@ func _on_items_loaded() -> void:
 func _on_recipes_loaded() -> void:
 	if recipes != null:
 		recipes_link.recipes = recipes.recipes_resource
-
-
-func _input(event: InputEvent) -> void:
-	if visible and event is InputEventKey:
-		if not event.is_pressed() or event.is_echo():
-			return
-		if event.keycode == KEY_TAB:
-			if event.ctrl_pressed:
-				if  event.shift_pressed:
-					tool_tab_bar.current_tab = posmod(tool_tab_bar.current_tab - 1, tool_count)
-				else:
-					tool_tab_bar.current_tab = posmod(tool_tab_bar.current_tab + 1, tool_count)
-				get_viewport().set_input_as_handled()
-		if event.keycode == KEY_W:
-			if event.ctrl_pressed:
-				if discourse != null and discourse.visible:
-					discourse.close_active_conversation()
-					get_viewport().set_input_as_handled()
-				elif characters != null and characters.visible:
-					characters.close_active_character()
-					get_viewport().set_input_as_handled()
-				elif phrase_maps != null and phrase_maps.visible:
-					phrase_maps.close_active_map()
-					get_viewport().set_input_as_handled()
 
 
 func _on_tab_changed(tab: int) -> void:

--- a/addons/nexus_forge/phrases/localization_resources.tscn
+++ b/addons/nexus_forge/phrases/localization_resources.tscn
@@ -287,6 +287,7 @@ layout_mode = 2
 size_flags_horizontal = 3
 size_flags_stretch_ratio = 2.0
 focus_next = NodePath("../ExpandDefaultBtn")
+editable = false
 
 [node name="ExpandDefaultBtn" type="Button" parent="MainContainer/DataHSplit/CaseContainer/CasesContainer/KeyScroll/CasesContainer/DefaultCaseContainer" unique_id=1399405752]
 custom_minimum_size = Vector2(33, 33)

--- a/addons/nexus_forge/phrases/localization_resources_script.gd
+++ b/addons/nexus_forge/phrases/localization_resources_script.gd
@@ -248,15 +248,13 @@ func _on_map_close_pressed(closing_map: int, requires_save: bool) -> void:
 		unsaved_dialog.show()
 		
 		var result: int = await unsaved_dialog.dialog_finished
+		unsaved_dialog.queue_free()
 		# 0 = save, 1 = don't save, 2 = cancel
 		if result == 0: # Save
 			save_current_resource()
 			ResourceSaver.save(map)
 		elif result == 2: # Cancel
-			unsaved_dialog.queue_free()
 			return
-		
-		unsaved_dialog.queue_free()
 	
 	if map == _open_files[closing_map]["resource"]:
 		clear_cases()
@@ -1213,7 +1211,7 @@ func _on_phrase_key_edit_toggled(is_toggled: bool, line: LineEdit) -> void:
 	var old_key: String = line.get_meta(&"old_value")
 	var new_key: String = get_valid_id(line.text, line)
 	
-	if new_key == old_key:
+	if line.text == new_key and new_key == old_key:
 		return
 	
 	undo.create_action("Rename Phrase Key")
@@ -1244,10 +1242,12 @@ func _on_phrase_text_focus_exited(field: TextEdit) -> void:
 
 
 func _on_case_edit_toggled(is_toggled: bool, line: LineEdit) -> void:
+	if is_toggled:
+		return
+	
 	var old_value: String = line.get_meta(&"old_value")
 	var new_value: String = get_valid_case_id(line.text, line)
-	
-	if new_value == old_value:
+	if line.text == new_value and new_value == old_value:
 		return
 	
 	var phrase_line: LineEdit = %EntriesContainer.get_child(selected_key_index).get_child(1)

--- a/addons/nexus_forge/phrases/localization_resources_script.gd
+++ b/addons/nexus_forge/phrases/localization_resources_script.gd
@@ -1219,7 +1219,9 @@ func _on_phrase_key_edit_toggled(is_toggled: bool, line: LineEdit) -> void:
 	var old_key: String = line.get_meta(&"old_value")
 	var new_key: String = get_valid_id(line.text, line)
 	
-	if line.text == new_key and new_key == old_key:
+	if new_key == old_key:
+		if line.text != new_key:
+			line.text = new_key
 		return
 	
 	undo.create_action("Rename Phrase Key")
@@ -1255,7 +1257,9 @@ func _on_case_edit_toggled(is_toggled: bool, line: LineEdit) -> void:
 	
 	var old_value: String = line.get_meta(&"old_value")
 	var new_value: String = get_valid_case_id(line.text, line)
-	if line.text == new_value and new_value == old_value:
+	if new_value == old_value:
+		if line.text != new_value:
+			line.text = new_value
 		return
 	
 	var phrase_line: LineEdit = %EntriesContainer.get_child(selected_key_index).get_child(1)

--- a/addons/nexus_forge/phrases/localization_resources_script.gd
+++ b/addons/nexus_forge/phrases/localization_resources_script.gd
@@ -47,61 +47,7 @@ var _open_files: Dictionary[int, Dictionary] = {}
 @onready var expand_default_btn: Button = $MainContainer/DataHSplit/CaseContainer/CasesContainer/KeyScroll/CasesContainer/DefaultCaseContainer/ExpandDefaultBtn
 
 
-func _ready() -> void:
-	set_process_input(false)
-
-
-func _input(event: InputEvent) -> void:
-	if not is_visible_in_tree():
-		return
-	
-	if event is InputEventKey:
-		if event.echo or not event.pressed or not event.ctrl_pressed:
-			return
-		
-		var current_focus: Control = get_viewport().gui_get_focus_owner()
-		
-		if current_focus != null:
-			if current_focus is LineEdit:
-				if current_focus.is_editing():
-					return
-			elif current_focus is TextEdit:
-				return
-		
-		if event.keycode == KEY_Z:
-			if event.shift_pressed:
-				if undo.has_redo():
-					var action_name: String = undo.get_action_name(undo.get_current_action() + 1)
-					undo.redo()
-					NFPluginGameHandler._log_msg(
-						"",
-						"Redo: " + action_name,
-						NFPluginGameHandler._LogLevel.EDITOR)
-					_on_file_edited()
-			else:
-				if undo.has_undo():
-					var action_name: String = undo.get_current_action_name()
-					undo.undo()
-					NFPluginGameHandler._log_msg(
-						"",
-						"Undo: " + action_name,
-						NFPluginGameHandler._LogLevel.EDITOR)
-					_on_file_edited()
-			get_viewport().set_input_as_handled()
-		elif event.keycode == KEY_Y and not event.shift_pressed:
-			if undo.has_redo():
-				var action_name: String = undo.get_action_name(undo.get_current_action() + 1)
-				undo.redo()
-				NFPluginGameHandler._log_msg(
-					"",
-					"Redo: " + action_name,
-					NFPluginGameHandler._LogLevel.EDITOR)
-				_on_file_edited()
-			get_viewport().set_input_as_handled()
-
-
 func ready_plugin() -> void:
-	set_process_input(true)
 	text_editor = load("res://addons/nexus_forge/discourse/discourse_text_editor.tscn").instantiate()
 	add_child(text_editor)
 	text_editor.signal_variables = true
@@ -179,6 +125,38 @@ func ready_plugin() -> void:
 	
 	search_text_ln_edt.text_changed.connect(_on_key_search_text_changed)
 	search_case_ln_edt.text_changed.connect(_on_case_search_text_changed)
+
+
+func can_undo() -> bool:
+	if is_instance_valid(undo):
+		return undo.has_undo()
+	return false
+
+
+func can_redo() -> bool:
+	if is_instance_valid(undo):
+		return undo.has_redo()
+	return false
+
+
+func do_undo() -> void:
+	var action_name: String = undo.get_current_action_name()
+	undo.undo()
+	NFPluginGameHandler._log_msg(
+		"",
+		"Undo: " + action_name,
+		NFPluginGameHandler._LogLevel.EDITOR)
+	_on_file_edited()
+
+
+func do_redo() -> void:
+	var action_name: String = undo.get_action_name(undo.get_current_action() + 1)
+	undo.redo()
+	NFPluginGameHandler._log_msg(
+		"",
+		"Redo: " + action_name,
+		NFPluginGameHandler._LogLevel.EDITOR)
+	_on_file_edited()
 
 
 func _on_case_line_text_changed(_text: String = "") -> void:

--- a/addons/nexus_forge/phrases/localization_resources_script.gd
+++ b/addons/nexus_forge/phrases/localization_resources_script.gd
@@ -258,11 +258,15 @@ func _on_map_close_pressed(closing_map: int, requires_save: bool) -> void:
 	
 	if map == _open_files[closing_map]["resource"]:
 		clear_cases()
+		selected_format = ""
+		expand_default_btn.disabled = true
+		selected_key_index = -1
 		default_case_text.clear()
 		default_case_text.editable = false
 		_update_choice_textbox_size(default_case_text)
 		argument_opt_btn.clear()
 		argument_opt_btn.disabled = true
+		new_case_btn.disabled = true
 		clear_keys()
 		map = null
 		undo = null
@@ -802,11 +806,15 @@ func close_active_map() -> void:
 	var id: int = map.get_instance_id()
 	
 	clear_cases()
+	selected_format = ""
+	expand_default_btn.disabled = true
+	selected_key_index = -1
 	default_case_text.clear()
 	default_case_text.editable = false
 	_update_choice_textbox_size(default_case_text)
 	argument_opt_btn.clear()
 	argument_opt_btn.disabled = true
+	new_case_btn.disabled = true
 	clear_keys()
 	
 	files_tree.remove_map(id)

--- a/addons/nexus_forge/phrases/localization_resources_script.gd
+++ b/addons/nexus_forge/phrases/localization_resources_script.gd
@@ -323,8 +323,8 @@ func _on_edit_cases_pressed(container: HBoxContainer) -> void:
 	
 	var phrase_key: StringName = container.get_child(1).get_meta(&"old_value")
 	
-	if not map.has_entry(phrase_key) or map.get_entry(phrase_key) != text_line.text.strip_edges():
-		map.set_entry(phrase_key, text_line.text.strip_edges())
+	if not map.has_entry(phrase_key) or map.get_entry(phrase_key) != text_line.text:
+		map.set_entry(phrase_key, text_line.text)
 	
 	argument_opt_btn.clear()
 	
@@ -615,7 +615,7 @@ func save_current_phrase_key() -> void:
 	
 	for case_index in range(1, %CasesContainer.get_child_count()):
 		var case_entry: HBoxContainer = %CasesContainer.get_child(case_index)
-		desired = case_entry.get_child(1).text.strip_edges()
+		desired = case_entry.get_child(1).text
 		modified = desired
 		iteration = 0
 		while cases.has(modified):
@@ -632,7 +632,7 @@ func save_current_phrase_key() -> void:
 				case,
 				cases[case])
 	
-	map.set_case_default(phrase_key, selected_format, default_case_text.text.strip_edges())
+	map.set_case_default(phrase_key, selected_format, default_case_text.text)
 
 
 func clear_keys() -> void:
@@ -1223,6 +1223,9 @@ func _on_phrase_key_edit_toggled(is_toggled: bool, line: LineEdit) -> void:
 
 
 func _on_phrase_text_focus_exited(field: TextEdit) -> void:
+	if not field.editable:
+		return
+	
 	var old_value: String = field.get_meta(&"old_value")
 	var new_value: String = field.text
 	
@@ -1232,9 +1235,11 @@ func _on_phrase_text_focus_exited(field: TextEdit) -> void:
 	var phrase_key_line: LineEdit = field.get_parent().get_child(1)
 	var phrase_key: StringName = StringName(phrase_key_line.get_meta(&"old_value"))
 	
+	var old_data: Dictionary = map._phrases.get(phrase_key, {}).duplicate(true)
+	
 	undo.create_action("Edit Phrase Text")
 	undo.add_do_method(_do_update_phrase_text.bind(phrase_key, new_value))
-	undo.add_undo_method(_do_update_phrase_text.bind(phrase_key, old_value))
+	undo.add_undo_method(_do_update_phrase_text.bind(phrase_key, old_value, old_data))
 	undo.commit_action()
 
 
@@ -1309,7 +1314,7 @@ func _do_update_prase_key(from: String, to: String) -> void:
 	target_line.set_meta(&"old_value", to)
 
 
-func _do_update_phrase_text(on_key: String, to: String) -> void:
+func _do_update_phrase_text(on_key: String, to: String, data: Dictionary = {}) -> void:
 	var idx: int = -1
 	var erase_btn: Button = null
 	var text_key: LineEdit = null
@@ -1318,7 +1323,10 @@ func _do_update_phrase_text(on_key: String, to: String) -> void:
 	var edit_button: Button = null
 	var phrase_key: StringName = StringName(on_key)
 	
-	map.set_entry(phrase_key, to)
+	if data.is_empty():
+		map.set_entry(phrase_key, to)
+	else:
+		map._phrases[phrase_key] = data.duplicate(true)
 	
 	for item in %EntriesContainer.get_children():
 		if item.is_queued_for_deletion():
@@ -1338,7 +1346,6 @@ func _do_update_phrase_text(on_key: String, to: String) -> void:
 		return
 	
 	if 0 <= selected_key_index and selected_key_index == idx:
-		save_current_phrase_key()
 		edit_button.icon = get_theme_icon("Edit", "EditorIcons")
 		edit_button.tooltip_text = "Edit Cases"
 		clear_cases()

--- a/addons/nexus_forge/phrases/localization_resources_script.gd
+++ b/addons/nexus_forge/phrases/localization_resources_script.gd
@@ -6,10 +6,12 @@ signal code_editor_variables_requested(path: String)
 const BRACKET_HANDLER = preload("res://addons/nexus_forge/discourse/textedit_bracket_handler.gd")
 const MAX_LINES: int = 3
 const EXTRA_Y_PADDING: int = 8
+const MAX_UNDO_STEPS: int = 50
 
 var selected_key_index: int = -1
 var selected_format: String = ""
 
+var api_path: String = ""
 var map: PhraseMap = null:
 	set(m):
 		map = m
@@ -17,9 +19,19 @@ var map: PhraseMap = null:
 		language_opt_btn.disabled = m == null
 		region_opt_btn.disabled = m == null
 
-var save_required: bool = false
+var save_required: bool = false:
+	set(s):
+		if map != null:
+			_open_files[map.get_instance_id()]["unsaved"] = s
+	get:
+		if map != null:
+			return _open_files[map.get_instance_id()]["unsaved"]
+		return false
 var text_editor: Window = null
 var standard_regex: RegEx = null
+
+var undo: UndoRedo
+var _open_files: Dictionary[int, Dictionary] = {}
 
 @onready var search_file_ln_edt: LineEdit = $MainContainer/FilesContainer/SearchContainer/SearchFileLnEdt
 @onready var file_menu_button: MenuButton = $MainContainer/FilesContainer/SearchContainer/FileMenuButton
@@ -28,18 +40,11 @@ var standard_regex: RegEx = null
 @onready var region_opt_btn: OptionButton = $MainContainer/FilesContainer/LanguageContainer/RegionContainer/RegionOptBtn
 @onready var search_text_ln_edt: LineEdit = $MainContainer/DataHSplit/TextContainer/HBoxContainer/SearchTextLnEdt
 @onready var new_text_button: Button = $MainContainer/DataHSplit/TextContainer/HBoxContainer/NewTextButton
-#@onready var key_split_container: HSplitContainer = $MainContainer/DataHSplit/TextContainer/KeyScroll/KeySplitContainer
-#@onready var key_container: VBoxContainer = $MainContainer/DataHSplit/TextContainer/KeyScroll/KeySplitContainer/KeyContainer
-#@onready var text_container: VBoxContainer = $MainContainer/DataHSplit/TextContainer/KeyScroll/KeySplitContainer/TextContainer
 @onready var search_case_ln_edt: LineEdit = $MainContainer/DataHSplit/CaseContainer/HeaderContainer/SearchCaseLnEdt
 @onready var argument_opt_btn: OptionButton = $MainContainer/DataHSplit/CaseContainer/HeaderContainer/ArgumentOptBtn
 @onready var new_case_btn: Button = $MainContainer/DataHSplit/CaseContainer/HeaderContainer/NewCaseBtn
-#@onready var case_header_split: HSplitContainer = $MainContainer/DataHSplit/CaseContainer/CaseHeaderSplit
-#@onready var cases_split: HSplitContainer = $MainContainer/DataHSplit/CaseContainer/KeyScroll/CasesSplit
-#@onready var case_node_container: VBoxContainer = $MainContainer/DataHSplit/CaseContainer/KeyScroll/CasesSplit/CaseContainer/CaseNodeContainer
 @onready var default_case_text: TextEdit = $MainContainer/DataHSplit/CaseContainer/CasesContainer/KeyScroll/CasesContainer/DefaultCaseContainer/DefaultCaseText
 @onready var expand_default_btn: Button = $MainContainer/DataHSplit/CaseContainer/CasesContainer/KeyScroll/CasesContainer/DefaultCaseContainer/ExpandDefaultBtn
-#@onready var result_node_container: VBoxContainer = $MainContainer/DataHSplit/CaseContainer/KeyScroll/CasesSplit/ResultContainer/ResultNodeContainer
 
 
 func _ready() -> void:
@@ -64,8 +69,34 @@ func _input(event: InputEvent) -> void:
 				return
 		
 		if event.keycode == KEY_Z:
+			if event.shift_pressed:
+				if undo.has_redo():
+					var action_name: String = undo.get_action_name(undo.get_current_action() + 1)
+					undo.redo()
+					NFPluginGameHandler._log_msg(
+						"",
+						"Redo: " + action_name,
+						NFPluginGameHandler._LogLevel.EDITOR)
+					_on_file_edited()
+			else:
+				if undo.has_undo():
+					var action_name: String = undo.get_current_action_name()
+					undo.undo()
+					NFPluginGameHandler._log_msg(
+						"",
+						"Undo: " + action_name,
+						NFPluginGameHandler._LogLevel.EDITOR)
+					_on_file_edited()
 			get_viewport().set_input_as_handled()
 		elif event.keycode == KEY_Y and not event.shift_pressed:
+			if undo.has_redo():
+				var action_name: String = undo.get_action_name(undo.get_current_action() + 1)
+				undo.redo()
+				NFPluginGameHandler._log_msg(
+					"",
+					"Redo: " + action_name,
+					NFPluginGameHandler._LogLevel.EDITOR)
+				_on_file_edited()
 			get_viewport().set_input_as_handled()
 
 
@@ -109,6 +140,7 @@ func ready_plugin() -> void:
 	default_case_text.set_script(BRACKET_HANDLER)
 	default_case_text.syntax_highlighter = def_highlighter
 	default_case_text.enter_shifts_focus = true
+	default_case_text.set_meta(&"old_value", "")
 	
 	expand_default_btn.disabled = true
 	
@@ -138,89 +170,36 @@ func ready_plugin() -> void:
 	file_menu_button.get_popup().id_pressed.connect(_on_menu_id_pressed)
 	files_tree.map_close_pressed.connect(_on_map_close_pressed)
 	
-	language_opt_btn.item_selected.connect(_on_file_edited)
-	region_opt_btn.item_selected.connect(_on_file_edited)
+	language_opt_btn.item_selected.connect(_on_language_item_selected)
+	region_opt_btn.item_selected.connect(_on_region_item_selected)
 	
 	default_case_text.resized.connect(_update_choice_textbox_size.bind(default_case_text))
 	default_case_text.text_changed.connect(_on_text_field_changed.bind(default_case_text))
+	default_case_text.focus_exited.connect(_on_case_result_focus_exited.bind(default_case_text))
 	
 	search_text_ln_edt.text_changed.connect(_on_key_search_text_changed)
 	search_case_ln_edt.text_changed.connect(_on_case_search_text_changed)
 
 
 func _on_case_line_text_changed(_text: String = "") -> void:
-	validate_cases_entries()
 	_on_file_edited()
-
-
-func validate_cases_entries() -> void:
-	var all_ids: Dictionary[String, Array] = {}
-	var default_case: HBoxContainer = %CasesContainer.get_child(0)
-	
-	for node:HBoxContainer in %CasesContainer.get_children():
-		if node == default_case or node.is_queued_for_deletion():
-			continue
-		
-		var item: LineEdit = node.get_child(1)
-		var key: String = item.text.strip_edges()
-		
-		if key.is_empty():
-			continue
-		
-		if not all_ids.has(key):
-			all_ids[key] = []
-		all_ids[key].append(item)
-	
-	for item_key:String in all_ids.keys():
-		if 1 < all_ids[item_key].size():
-			for item:LineEdit in all_ids[item_key]:
-				item.add_theme_color_override(&"font_color", Color(1.0, 0.29, 0.325))
-		else:
-			for item:LineEdit in all_ids[item_key]:
-				if item.has_theme_color(&"font_color"):
-					item.remove_theme_color_override(&"font_color")
 
 
 func _on_key_line_text_changed(_text: String = "") -> void:
-	validate_phrase_keys()
 	_on_file_edited()
 
 
-func validate_phrase_keys() -> void:
-	var all_ids: Dictionary[String, Array] = {}
-	
-	for node in %EntriesContainer.get_children():
-		if node.is_queued_for_deletion():
-			continue
-		
-		var line: LineEdit = node.get_child(1)
-		var key: String = line.text.strip_edges()
-		
-		if key.is_empty():
-			continue
-		
-		if all_ids.has(key) == false:
-			all_ids[key] = []
-		all_ids[key].append(line)
-	
-	for item_key:String in all_ids.keys():
-		if 1 < all_ids[item_key].size():
-			for item:LineEdit in all_ids[item_key]:
-				item.add_theme_color_override(&"font_color", Color(1.0, 0.29, 0.325))
-		else:
-			for item:LineEdit in all_ids[item_key]:
-				if item.has_theme_color(&"font_color"):
-					item.remove_theme_color_override(&"font_color")
-	
-
-
-#func _on_text_line_text_submitted(_text: String, edit_btn: Button) -> void:
-	#edit_btn.grab_focus()
-
-
 func _on_erase_case_button_pressed(item: HBoxContainer) -> void:
-	erase_case(item.get_index() - 1)
-	validate_cases_entries()
+	var phrase_line: LineEdit = %EntriesContainer.get_child(selected_key_index).get_child(1)
+	var phrase_key: String = phrase_line.get_meta(&"old_value")
+	var format: String = argument_opt_btn.get_item_text(argument_opt_btn.selected)
+	var case_id: String = item.get_child(1).get_meta(&"old_value")
+	var case_result: String = item.get_child(2).text
+	
+	undo.create_action("Erase Case Entry")
+	undo.add_do_method(_do_erase_case_entry.bind(phrase_key, format, case_id))
+	undo.add_undo_method(_do_add_case_entry.bind(phrase_key, format, case_id, case_result))
+	undo.commit_action()
 
 
 func _on_erase_key_button_pressed(key_node: HBoxContainer) -> void:
@@ -235,11 +214,15 @@ func _on_erase_key_button_pressed(key_node: HBoxContainer) -> void:
 		argument_opt_btn.disabled = true
 		new_case_btn.disabled = true
 	
-	map.erase_entry(key_node.get_meta(&"phrase_key"))
+	var phrase_id: String = key_node.get_child(1).get_meta(&"old_value")
+	var phrase_key: StringName = StringName(phrase_id)
+	var data: Dictionary = map._phrases.get(phrase_key, {}).duplicate(true)
+	var current_text: String = key_node.get_child(2).text
 	
-	erase_key(key_node.get_index())
-	
-	validate_phrase_keys()
+	undo.create_action("Erase Phrase Entry")
+	undo.add_do_method(_do_erase_phrase_entry.bind(phrase_id))
+	undo.add_undo_method(_do_add_phrase_entry.bind(phrase_id, current_text, data))
+	undo.commit_action()
 
 
 func _on_format_item_selected(idx: int) -> void:
@@ -253,10 +236,12 @@ func _on_format_item_selected(idx: int) -> void:
 	search_case_ln_edt.set_meta(&"current_search", "")
 	clear_cases()
 	
-	var phrase_key: StringName = %EntriesContainer.get_child(selected_key_index).get_meta(&"phrase_key")
+	var phrase_key: StringName = StringName(%EntriesContainer.get_child(selected_key_index).get_child(1).get_meta(&"old_value"))
 	var format_argument: String = argument_opt_btn.get_item_text(idx)
+	var default_case: String = map.get_case_default(phrase_key, format_argument)
+	default_case_text.text = default_case
+	default_case_text.set_meta(&"old_value", default_case)
 	
-	default_case_text.text = map.get_case_default(phrase_key, format_argument)
 	_update_choice_textbox_size(default_case_text)
 	
 	for case in map._phrases[phrase_key]["formats"][format_argument]["cases"].keys():
@@ -267,15 +252,16 @@ func _on_format_item_selected(idx: int) -> void:
 	selected_format = format_argument
 
 
-func _on_map_resource_selected(new_map: PhraseMap) -> void:
+func _on_map_resource_selected(new_map: int) -> void:
+	if not _open_files.has(new_map) or _open_files[new_map]["resource"] == map:
+		return
 	if map != null:
 		save_current_resource()
-	load_map(new_map)
-	map = new_map
-	save_required = false
+	load_map(_open_files[new_map]["resource"])
+	map = _open_files[new_map]["resource"]
 
 
-func _on_map_close_pressed(closing_map: PhraseMap, requires_save: bool) -> void:
+func _on_map_close_pressed(closing_map: int, requires_save: bool) -> void:
 	if requires_save:
 		var unsaved_dialog: AcceptDialog = load("res://addons/nexus_forge/dialogs/unsaved_dialog_script.gd").new()
 		unsaved_dialog.dialog_text = "File has unsaved changes\nDo you want to save before closing?"
@@ -294,18 +280,21 @@ func _on_map_close_pressed(closing_map: PhraseMap, requires_save: bool) -> void:
 		
 		unsaved_dialog.queue_free()
 	
-	if map == closing_map:
+	if map == _open_files[closing_map]["resource"]:
 		clear_cases()
 		default_case_text.clear()
 		default_case_text.editable = false
 		_update_choice_textbox_size(default_case_text)
 		argument_opt_btn.clear()
 		argument_opt_btn.disabled = true
-		
 		clear_keys()
-		
 		map = null
+		undo = null
 	
+	_open_files[closing_map]["undo"].clear_history()
+	_open_files[closing_map]["undo"].free()
+	_open_files[closing_map]["undo"] = null
+	_open_files.erase(closing_map)
 	files_tree.remove_map(closing_map)
 
 
@@ -354,7 +343,7 @@ func _on_edit_cases_pressed(container: HBoxContainer) -> void:
 	edit_button.tooltip_text = "Unlock"
 	selected_key_index = container.get_index()
 	
-	var phrase_key: StringName = container.get_meta(&"phrase_key")
+	var phrase_key: StringName = container.get_child(1).get_meta(&"old_value")
 	
 	if not map.has_entry(phrase_key) or map.get_entry(phrase_key) != text_line.text.strip_edges():
 		map.set_entry(phrase_key, text_line.text.strip_edges())
@@ -370,8 +359,10 @@ func _on_edit_cases_pressed(container: HBoxContainer) -> void:
 	
 	if 0 < argument_opt_btn.item_count:
 		var argument_format: String = argument_opt_btn.get_item_text(0)
+		var default_case: String = map.get_case_default(phrase_key, argument_format)
 		argument_opt_btn.select(0)
-		default_case_text.text = map.get_case_default(phrase_key, argument_format)
+		default_case_text.text = default_case
+		default_case_text.set_meta(&"old_value", default_case)
 		_update_choice_textbox_size(default_case_text)
 		for custom_case in map._phrases[phrase_key]["formats"][argument_format]["cases"].keys():
 			create_case_entry(
@@ -381,7 +372,13 @@ func _on_edit_cases_pressed(container: HBoxContainer) -> void:
 
 
 func _on_new_key_field_button_pressed() -> void:
-	create_key_text_entry(&"", "")
+	var new_id: String = get_valid_id("NEW_PHRASE")
+	
+	undo.create_action("Add Phrase Entry")
+	undo.add_do_method(_do_add_phrase_entry.bind(new_id, ""))
+	undo.add_undo_method(_do_erase_phrase_entry.bind(new_id))
+	undo.commit_action()
+	
 	_on_file_edited()
 
 
@@ -389,11 +386,20 @@ func _on_file_edited(_arg = null) -> void:
 	if save_required:
 		return
 	save_required = true
-	files_tree.set_save_required(map, true)
+	files_tree.set_save_required(map.get_instance_id(), true)
 
 
 func _on_new_case_button_pressed() -> void:
-	create_case_entry("", "")
+	var new_case_id: String = get_valid_case_id("new case")
+	var phrase_line: LineEdit = %EntriesContainer.get_child(selected_key_index).get_child(1)
+	var phrase_key: String = phrase_line.get_meta(&"old_value")
+	var format: String = argument_opt_btn.get_item_text(argument_opt_btn.selected)
+	
+	undo.create_action("Add Case Entry")
+	undo.add_do_method(_do_add_case_entry.bind(phrase_key, format, new_case_id, ""))
+	undo.add_undo_method(_do_erase_case_entry.bind(phrase_key, format, new_case_id))
+	undo.commit_action()
+	
 	_on_file_edited()
 
 
@@ -412,40 +418,55 @@ func _on_menu_id_pressed(id: int) -> void:
 	map_dialog.show()
 	
 	var result: Array = await map_dialog.dialog_finished # (success: bool, resource_path: String)
+	map_dialog.queue_free()
 	
-	if result[0]:
-		if id == 0: # New file
-			var lang: String = language_opt_btn.get_selected_metadata().to_lower()
-			var reg: String = region_opt_btn.get_selected_metadata().to_upper()
-			var locale_code: String = lang if reg.is_empty() else lang + "_" + reg
+	if not result[0]:
+		return
+	
+	if id == 0: # New file
+		var lang: String = language_opt_btn.get_selected_metadata().to_lower()
+		var reg: String = region_opt_btn.get_selected_metadata().to_upper()
+		var locale_code: String = lang if reg.is_empty() else lang + "_" + reg
+		
+		if 0 <= selected_key_index:
+			save_current_resource()
+		var new_map: PhraseMap = PhraseMap.new()
+		var new_undo: UndoRedo = UndoRedo.new()
+		new_undo.max_steps = MAX_UNDO_STEPS
+		new_map.locale = locale_code
+		
+		if ResourceLoader.has_cached(result[1]):
+			new_map.take_over_path(result[1])
+		new_map.resource_path = result[1]
+		ResourceSaver.save(new_map, result[1])
+		files_tree.add_map(new_map, true, false)
+		_open_files[new_map.get_instance_id()] = {
+			"resource": new_map,
+			"undo": new_undo,
+			"unsaved": false}
+		load_map(new_map)
+		map = new_map
+	elif id == 1:
+		var res_pre: Resource = load(result[1])
+		if res_pre is PhraseMap:
+			if res_pre == map:
+				return
 			
 			if 0 <= selected_key_index:
 				save_current_resource()
-			var new_map: PhraseMap = PhraseMap.new()
-			new_map.locale = locale_code
 			
-			if ResourceLoader.has_cached(result[1]):
-				new_map.take_over_path(result[1])
-			new_map.resource_path = result[1]
-			ResourceSaver.save(new_map, result[1])
-			files_tree.add_map(new_map, true, false)
-			load_map(new_map)
-			map = new_map
-			save_required = false
-		elif id == 1:
-			var res_pre: Resource = load(result[1])
-			if res_pre is PhraseMap:
-				if 0 <= selected_key_index:
-					save_current_resource()
-				
-				if files_tree.has_map(res_pre):
-					files_tree.select_map(res_pre, false)
-				else:
-					files_tree.add_map(res_pre, true, false)
-				load_map(res_pre)
-				map = res_pre
-				save_required = false
-	map_dialog.queue_free()
+			if _open_files.has(res_pre.get_instance_id()):
+				files_tree.select_map(res_pre, false)
+			else:
+				var new_undo: UndoRedo = UndoRedo.new()
+				new_undo.max_steps = MAX_UNDO_STEPS
+				_open_files[res_pre.get_instance_id()] = {
+					"resource": res_pre,
+					"undo": new_undo,
+					"unsaved": false}
+				files_tree.add_map(res_pre, true, false)
+			load_map(res_pre)
+			map = res_pre
 
 
 func _on_key_search_text_changed(text: String) -> void:
@@ -458,8 +479,6 @@ func _on_key_search_text_changed(text: String) -> void:
 	
 	if mode != 0:
 		clean_text = clean_text.trim_prefix("key:" if mode == 1 else "text:")
-	
-	#var idx: int = -1
 	
 	if clean_text.is_empty():
 		for node in %EntriesContainer.get_children():
@@ -511,18 +530,26 @@ func plugin_open_resource(resource: PhraseMap) -> void:
 	elif map != null:
 		save_current_resource()
 	
-	if files_tree.has_map(resource):
-		files_tree.select_map(resource, false)
+	if _open_files.has(resource.get_instance_id()):
+		files_tree.select_map(resource.get_instance_id(), false)
 	else:
+		var new_undo: UndoRedo = UndoRedo.new()
+		new_undo.max_steps = MAX_UNDO_STEPS
+		_open_files[resource.get_instance_id()] = {
+			"resource": resource,
+			"undo": new_undo,
+			"unsaved": false}
 		files_tree.add_map(resource, true, false)
 	
 	load_map(resource)
 	map = resource
-	save_required = false
 
 
 func get_open_maps() -> Array[String]:
-	return files_tree.get_open_files()
+	var maps: Array[String] = []
+	for id in _open_files:
+		maps.append(_open_files[id]["resource"].resource_path)
+	return maps
 
 
 func open_map_files(files: Array[String]) -> void:
@@ -530,10 +557,16 @@ func open_map_files(files: Array[String]) -> void:
 		if not FileAccess.file_exists(file):
 			continue
 		var res_load: Resource = load(file)
-		if res_load != null and res_load is PhraseMap:
-			if files_tree.has_map(res_load):
-				continue
-			files_tree.add_map(res_load, false)
+		if res_load == null or res_load is not PhraseMap or _open_files.has(res_load.get_instance_id()):
+			continue
+		
+		var new_undo: UndoRedo = UndoRedo.new()
+		new_undo.max_steps = MAX_UNDO_STEPS
+		_open_files[res_load.get_instance_id()] = {
+			"resource": res_load,
+			"undo": new_undo,
+			"unsaved": false}
+		files_tree.add_map(res_load, false)
 
 
 func select_language(language_code: String) -> void:
@@ -543,17 +576,20 @@ func select_language(language_code: String) -> void:
 	for idx in range(language_opt_btn.item_count):
 		if language_opt_btn.get_item_metadata(idx) == language_code:
 			language_opt_btn.select(idx)
+			language_opt_btn.set_meta(&"old_value", language_opt_btn.get_item_metadata(idx))
 			return
 
 
 func select_region(country_code: String) -> void:
 	if country_code.is_empty():
 		region_opt_btn.select(0)
+		region_opt_btn.set_meta(&"old_value", "")
 		return
 	
 	for idx in range(region_opt_btn.item_count):
 		if region_opt_btn.get_item_metadata(idx) == country_code:
 			region_opt_btn.select(idx)
+			region_opt_btn.set_meta(&"old_value", region_opt_btn.get_item_metadata(idx))
 			return
 
 
@@ -583,16 +619,17 @@ func load_map(new_map: PhraseMap) -> void:
 	
 	for key:StringName in new_map.entries():
 		create_key_text_entry(key, new_map.get_entry(key))
+	
+	undo = _open_files[new_map.get_instance_id()]["undo"]
 
 
-func save_current_phrase_key(fix_cases: bool = false) -> void:
+func save_current_phrase_key() -> void:
 	if selected_key_index < 0:
 		return
 	
-	var phrase_key: StringName = %EntriesContainer.get_child(selected_key_index).get_meta(&"phrase_key")
+	var phrase_key: StringName = %EntriesContainer.get_child(selected_key_index).get_child(1).get_meta(&"old_value")
 	
 	var cases: Dictionary[String, String] = {}
-	var node_map: Dictionary[String, LineEdit] = {}
 	
 	var desired: String = ""
 	var modified: String = ""
@@ -607,7 +644,6 @@ func save_current_phrase_key(fix_cases: bool = false) -> void:
 			iteration += 1
 			modified = desired + str(iteration)
 		cases[modified] = case_entry.get_child(2).text
-		node_map[modified] = case_entry.get_child(1)
 	
 	map.clear_cases(phrase_key, selected_format)
 	
@@ -617,14 +653,8 @@ func save_current_phrase_key(fix_cases: bool = false) -> void:
 				selected_format,
 				case,
 				cases[case])
-		
-		if fix_cases and case != node_map[case].text.strip_edges():
-			node_map[case].text = case
 	
 	map.set_case_default(phrase_key, selected_format, default_case_text.text.strip_edges())
-	
-	if fix_cases:
-		validate_cases_entries()
 
 
 func clear_keys() -> void:
@@ -701,9 +731,9 @@ func erase_key(index: int) -> void:
 	item.queue_free()
 
 
-func save_current_resource(fix_keys: bool = false) -> void:
+func save_current_resource() -> void:
 	if selected_format != "":
-		save_current_phrase_key(fix_keys)
+		save_current_phrase_key()
 	
 	var lang: String = language_opt_btn.get_selected_metadata().to_lower()
 	var reg: String = region_opt_btn.get_selected_metadata().to_upper()
@@ -715,63 +745,49 @@ func save_current_resource(fix_keys: bool = false) -> void:
 	var keys: Dictionary[String, String] = {}
 	
 	# Correct key: Line field
-	#var node_map: Dictionary[String, LineEdit] = {}
-	
 	var new_phrases: Dictionary[StringName, Dictionary]
 	
 	for key_node in %EntriesContainer.get_children():
 		if key_node.is_queued_for_deletion():
 			continue
-		var entry_key: StringName = key_node.get_meta(&"phrase_key")
-		var desired_id: String = key_node.get_child(1).text.strip_edges()
-		var trailing_int: Dictionary = StringUtils.get_trailing_integer(desired_id)
-		var iteration: int = trailing_int["integer"]
-		var modified: String = desired_id
-		
-		if trailing_int["has_integer"]:
-			desired_id = desired_id.trim_suffix(str(iteration))
-		
-		while keys.has(modified):
-			iteration += 1
-			modified = desired_id + str(iteration)
+		var entry_key: StringName = StringName(key_node.get_child(1).get_meta(&"old_value"))
 		
 		# Update the entry first.
 		map.set_entry(
 				entry_key,
 				key_node.get_child(2).text)
-		
-		# Store the entry with the correct key.
-		new_phrases[modified] = map._phrases[entry_key]
-		
-		key_node.set_meta(&"phrase_key", modified) # Update the key on the node
-		
-		if fix_keys:
-			key_node.get_child(1).text = modified
-	
-	# Assign the correct map to the dictionary.
-	map._phrases.assign(new_phrases)
-	
-	if fix_keys:
-		validate_phrase_keys()
 
 
 func has_unsaved_files() -> bool:
-	return files_tree.has_unsaved()
+	for id in _open_files:
+		if _open_files[id]["unsaved"]:
+			return true
+	return false
 
 
 func save_all() -> void:
-	for resource:PhraseMap in files_tree.get_unsaved_resources():
-		if resource == map:
-			save_current_resource(true)
-		ResourceSaver.save(resource)
+	if save_required:
+		save_current_resource()
+	
+	for id in _open_files:
+		if _open_files[id]["unsaved"]:
+			ResourceSaver.save(_open_files[id]["resource"])
+			_open_files[id]["unsaved"] = false
 	files_tree.set_save_required_all(false)
-	save_required = false
 
 
 func filesystem_resource_removed(resource: Resource) -> void:
 	if resource == null:
 		return
-	files_tree.remove_map(resource)
+	var id: int = resource.get_instance_id()
+	if not _open_files.has(id):
+		return
+	
+	_open_files[id]["undo"].clear_history()
+	_open_files[id]["undo"].free()
+	_open_files[id]["undo"] = null
+	_open_files.erase(id)
+	
 	if map == resource:
 		clear_cases()
 		default_case_text.clear()
@@ -781,13 +797,16 @@ func filesystem_resource_removed(resource: Resource) -> void:
 		argument_opt_btn.disabled = true
 		clear_keys()
 		map = null
+		undo = null
+	
+	files_tree.remove_map(id)
 
 
 func close_active_map() -> void:
 	if map == null:
 		return
 	
-	if files_tree.requires_save(map):
+	if save_required:
 		var unsaved_dialog: AcceptDialog = load("res://addons/nexus_forge/dialogs/unsaved_dialog_script.gd").new()
 		unsaved_dialog.dialog_text = "File has unsaved changes\nDo you want to save before closing?"
 		unsaved_dialog.title = "Save changes..."
@@ -795,15 +814,16 @@ func close_active_map() -> void:
 		unsaved_dialog.show()
 		
 		var result: int = await unsaved_dialog.dialog_finished
+		unsaved_dialog.queue_free()
+		
 		# 0 = save, 1 = don't save, 2 = cancel
 		if result == 0: # Save
 			save_current_resource()
 			ResourceSaver.save(map)
 		elif result == 2: # Cancel
-			unsaved_dialog.queue_free()
 			return
-		
-		unsaved_dialog.queue_free()
+	
+	var id: int = map.get_instance_id()
 	
 	clear_cases()
 	default_case_text.clear()
@@ -811,12 +831,16 @@ func close_active_map() -> void:
 	_update_choice_textbox_size(default_case_text)
 	argument_opt_btn.clear()
 	argument_opt_btn.disabled = true
-	
 	clear_keys()
 	
-	files_tree.remove_map(map)
+	files_tree.remove_map(id)
+	_open_files[id]["undo"].clear_history()
+	_open_files[id]["undo"].free()
+	_open_files[id]["undo"] = null
+	_open_files.erase(id)
 	
 	map = null
+	undo = null
 
 
 func create_case_entry(case: String, format: String) -> void:
@@ -837,6 +861,7 @@ func create_case_entry(case: String, format: String) -> void:
 	case_line.size_flags_vertical = Control.SIZE_SHRINK_CENTER
 	case_line.size_flags_stretch_ratio = 1.0
 	case_line.custom_minimum_size = Vector2(115.0, 33.0)
+	case_line.set_meta(&"old_value", case)
 	
 	case_text.syntax_highlighter = highlighter
 	case_text.caret_blink = true
@@ -846,6 +871,7 @@ func create_case_entry(case: String, format: String) -> void:
 	case_text.size_flags_stretch_ratio = 2.0
 	case_text.text = format
 	case_text.enter_shifts_focus = true
+	case_text.set_meta(&"old_value", format)
 	
 	erase_btn.tooltip_text = "Erase case"
 	erase_btn.icon_alignment = HORIZONTAL_ALIGNMENT_CENTER
@@ -882,12 +908,14 @@ func create_case_entry(case: String, format: String) -> void:
 	expand_text.focus_previous = case_text.get_path()
 	
 	case_line.text_submitted.connect(_on_case_key_text_submitted.bind(case_line))
+	case_line.editing_toggled.connect(_on_case_edit_toggled.bind(case_line))
 	
 	case_text.resized.connect(_update_choice_textbox_size.bind(case_text))
 	case_text.text_changed.connect(_on_text_field_changed.bind(case_text))
+	case_text.focus_exited.connect(_on_case_result_focus_exited.bind(case_text))
 
 
-func create_key_text_entry(key: StringName, text_entry: String) -> void:
+func create_key_text_entry(key: String, text_entry: String) -> void:
 	var container: HBoxContainer = HBoxContainer.new()
 	var erase_button: Button = Button.new()
 	var key_line: LineEdit = LineEdit.new()
@@ -904,17 +932,13 @@ func create_key_text_entry(key: StringName, text_entry: String) -> void:
 	text_editor.syntax_highlighter = highligher
 	text_editor.enter_shifts_focus = true
 	
-	if key.is_empty():
-		container.set_meta(&"phrase_key", StringName(UUID.generate_new()))
-	else:
-		container.set_meta(&"phrase_key", key)
-	
 	key_line.caret_blink = true
 	key_line.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	key_line.size_flags_vertical = Control.SIZE_SHRINK_CENTER
 	key_line.custom_minimum_size = Vector2(115.0, 33.0)
 	key_line.placeholder_text = "Key"
-	key_line.text = String(key)
+	key_line.text = key
+	key_line.set_meta(&"old_value", key)
 	key_line.size_flags_stretch_ratio = 1.0
 	
 	erase_button.icon = get_theme_icon("Remove", "EditorIcons")
@@ -931,6 +955,7 @@ func create_key_text_entry(key: StringName, text_entry: String) -> void:
 	text_editor.placeholder_text = "Phrase Text"
 	text_editor.wrap_mode = TextEdit.LINE_WRAPPING_BOUNDARY
 	text_editor.size_flags_stretch_ratio = 2.0
+	text_editor.set_meta(&"old_value", text_entry)
 	
 	edit_button.custom_minimum_size = Vector2(33.0, 33.0)
 	edit_button.icon_alignment = HORIZONTAL_ALIGNMENT_CENTER
@@ -974,9 +999,13 @@ func create_key_text_entry(key: StringName, text_entry: String) -> void:
 	
 	key_line.text_changed.connect(_on_key_line_text_changed)
 	key_line.text_submitted.connect(_on_case_key_text_submitted.bind(key_line))
-	erase_button.pressed.connect(_on_erase_key_button_pressed.bind(container))
+	key_line.editing_toggled.connect(_on_phrase_key_edit_toggled.bind(key_line))
+	
 	text_editor.text_changed.connect(_on_text_field_changed.bind(text_editor))
 	text_editor.resized.connect(_update_choice_textbox_size.bind(text_editor))
+	text_editor.focus_exited.connect(_on_phrase_text_focus_exited.bind(text_editor))
+	
+	erase_button.pressed.connect(_on_erase_key_button_pressed.bind(container))
 	expand_button.pressed.connect(_on_open_focus_editor_pressed.bind(text_editor, true))
 	edit_button.pressed.connect(_on_edit_cases_pressed.bind(container))
 
@@ -986,6 +1015,36 @@ func set_text_code_editor_variable_paths(paths: Array[Dictionary]) -> void:
 		return
 	
 	text_editor.display_completion_options_variables(paths)
+
+
+func _on_language_item_selected(idx: int) -> void:
+	var old_language: String = language_opt_btn.get_meta(&"old_value")
+	var new_lang: String = language_opt_btn.get_item_metadata(idx)
+	
+	if new_lang == old_language:
+		return
+	
+	_on_file_edited()
+	language_opt_btn.set_meta(&"old_value", new_lang)
+	undo.create_action("Set Language")
+	undo.add_do_method(select_language.bind(new_lang))
+	undo.add_undo_method(select_language.bind(old_language))
+	undo.commit_action(false)
+
+
+func _on_region_item_selected(idx: int) -> void:
+	var old_region: String = region_opt_btn.get_meta(&"old_value")
+	var new_region: String = region_opt_btn.get_item_metadata(idx)
+	
+	if new_region == old_region:
+		return
+	
+	_on_file_edited()
+	region_opt_btn.set_meta(&"old_value", new_region)
+	undo.create_action("Set Region")
+	undo.add_do_method(select_region.bind(new_region))
+	undo.add_undo_method(select_region.bind(old_region))
+	undo.commit_action(false)
 
 
 func _on_case_key_text_submitted(_text: String, field: LineEdit) -> void:
@@ -1082,30 +1141,400 @@ func _on_editor_variable_called(path: String) -> void:
 
 
 func get_api_user_methods() -> Array[String]:
+	if api_path.is_empty() or not FileAccess.file_exists(api_path):
+		var all_classes: Array[Dictionary] = ProjectSettings.get_global_class_list()
+		for class_entry in all_classes:
+			if class_entry["class"] == "PhraseAPI":
+				api_path = class_entry["path"]
+				break
+	
 	var methods: Array[String] = []
+	if api_path.is_empty() or not FileAccess.file_exists(api_path):
+		NFPluginGameHandler._log_msg(
+				"phrase maps - editor",
+				"Unable to locate PhraseAPI class file",
+				NFPluginGameHandler._LogLevel.ERROR)
+		return methods
 	
-	var method_blacklsit: Array[String] = []
-	var singleton: PhraseAPI = PhraseAPI.new()
-	var base_methods: Array = ClassDB.class_get_method_list(&"RefCounted")
+	var api_script: Script = load(api_path)
 	
-	for method in base_methods:
-		method_blacklsit.append(method["name"])
-		
-	for method:Dictionary in singleton.get_method_list():
-		if method["name"] in method_blacklsit or method["return"]["type"] == TYPE_NIL:
+	for method:Dictionary in api_script.get_script_method_list():
+		if method["return"]["type"] == TYPE_NIL:
 			continue
 		
-		#var default_count: int = method["default_args"].size()
-		#var default_index: int = method["args"].size() - default_count
-		#var args: Array[Dictionary] = []
-		#var arg_idx: int = -1
-		#for arg: Dictionary in method["args"]:
-			#arg_idx += 1
-			#args.append({
-				#"name": arg["name"],
-				#"type": arg["type"],
-				#"has_default": default_index <= arg_idx})
-		#methods[method["name"]] = {"return_type": method["return"]["type"], "arguments": args}
 		methods.append(method["name"])
 	
 	return methods
+
+
+func get_valid_id(desired: String, ignore_node: LineEdit = null) -> String:
+	var all_ids: Dictionary[String, Variant] = {}
+	
+	for node in %EntriesContainer.get_children():
+		if node.is_queued_for_deletion():
+			continue
+		var line: LineEdit = node.get_child(1)
+		if line == ignore_node:
+			continue
+		var key: String = line.text
+		all_ids[key] = null
+	
+	if not all_ids.has(desired):
+		return desired
+	
+	var modified: String = desired.strip_edges()
+	var base: String = modified
+	var trailing_data: Dictionary = StringUtils.get_trailing_integer(modified)
+	var iteration: int = trailing_data["integer"]
+	if trailing_data["has_integer"]:
+		base = base.trim_suffix(str(iteration))
+	
+	while all_ids.has(modified):
+		iteration += 1
+		modified = base + str(iteration)
+	
+	return modified
+
+
+func get_valid_case_id(desired: String, ignore_node: LineEdit = null) -> String:
+	var all_ids: Dictionary[String, Variant] = {}
+	var default_case: HBoxContainer = %CasesContainer.get_child(0)
+	
+	for node_idx in range(1, %CasesContainer.get_child_count()):
+		var node: HBoxContainer = %CasesContainer.get_child(node_idx)
+		if node.is_queued_for_deletion():
+			continue
+		var item: LineEdit = node.get_child(1)
+		if item == ignore_node:
+			continue
+		
+		var key: String = item.text
+		all_ids[key] = null
+	
+	if not all_ids.has(desired):
+		return desired
+	
+	var modified: String = desired.strip_edges()
+	var base: String = modified
+	var trailing_data: Dictionary = StringUtils.get_trailing_integer(modified)
+	var iteration: int = trailing_data["integer"]
+	if trailing_data["has_integer"]:
+		base = base.trim_suffix(str(iteration))
+	
+	while all_ids.has(modified):
+		iteration += 1
+		modified = base + str(iteration)
+	
+	return modified
+
+
+func _on_phrase_key_edit_toggled(is_toggled: bool, line: LineEdit) -> void:
+	if is_toggled:
+		return
+	
+	var old_key: String = line.get_meta(&"old_value")
+	var new_key: String = get_valid_id(line.text, line)
+	
+	if new_key == old_key:
+		return
+	
+	undo.create_action("Rename Phrase Key")
+	undo.add_do_method(_do_update_prase_key.bind(old_key, new_key))
+	undo.add_undo_method(_do_update_prase_key.bind(new_key, old_key))
+	undo.commit_action()
+
+
+func _on_phrase_text_focus_exited(field: TextEdit) -> void:
+	var old_value: String = field.get_meta(&"old_value")
+	var new_value: String = field.text
+	
+	if new_value == old_value:
+		return
+	
+	var phrase_key_line: LineEdit = field.get_parent().get_child(1)
+	var phrase_key: StringName = StringName(phrase_key_line.get_meta(&"old_value"))
+	
+	undo.create_action("Edit Phrase Text")
+	undo.add_do_method(_do_update_phrase_text.bind(phrase_key, new_value))
+	undo.add_undo_method(_do_update_phrase_text.bind(phrase_key, old_value))
+	undo.commit_action()
+
+
+func _on_case_edit_toggled(is_toggled: bool, line: LineEdit) -> void:
+	var old_value: String = line.get_meta(&"old_value")
+	var new_value: String = get_valid_case_id(line.text, line)
+	
+	if new_value == old_value:
+		return
+	
+	var phrase_line: LineEdit = %EntriesContainer.get_child(selected_key_index).get_child(1)
+	var phrase_key: StringName = StringName(phrase_line.get_meta(&"old_value"))
+	var format: String = argument_opt_btn.get_item_text(argument_opt_btn.selected)
+	
+	undo.create_action("Rename Case Key")
+	undo.add_do_method(_do_update_case_key.bind(phrase_key, format, old_value, new_value))
+	undo.add_undo_method(_do_update_case_key.bind(phrase_key, format, new_value, old_value))
+	undo.commit_action()
+
+
+func _on_case_result_focus_exited(field: TextEdit) -> void:
+	if undo == null:
+		return
+	
+	var is_default: bool = field == default_case_text
+	var old_value: String = field.get_meta(&"old_value")
+	var new_value: String = field.text
+	
+	if new_value == old_value:
+		return
+	
+	var phrase_line: LineEdit = %EntriesContainer.get_child(selected_key_index).get_child(1)
+	var phrase_key: StringName = StringName(phrase_line.get_meta(&"old_value"))
+	var format: String = argument_opt_btn.get_item_text(argument_opt_btn.selected)
+	
+	if is_default:
+		undo.create_action("Edit Default Case")
+		undo.add_do_method(_do_update_case_default_result.bind(phrase_key, format, new_value))
+		undo.add_undo_method(_do_update_case_default_result.bind(phrase_key, format, old_value))
+		undo.commit_action()
+	else:
+		var case_line: LineEdit = field.get_parent().get_child(1)
+		var case_text: String = case_line.get_meta(&"old_value")
+		undo.create_action("Edit Case Result")
+		undo.add_do_method(_do_update_case_result.bind(phrase_key, format, case_text, new_value))
+		undo.add_undo_method(_do_update_case_result.bind(phrase_key, format, case_text, old_value))
+		undo.commit_action()
+
+
+func _do_update_prase_key(from: String, to: String) -> void:
+	var target_line: LineEdit = null
+	
+	if map._phrases.has(from):
+		map._phrases[to] = map._phrases[from]
+		map._phrases.erase(from)
+	
+	for item in %EntriesContainer.get_children():
+		if item.is_queued_for_deletion():
+			continue
+		var line: LineEdit = item.get_child(1)
+		
+		if line.get_meta(&"old_value") == from:
+			target_line = line
+			break
+	
+	if target_line == null:
+		return
+	
+	var old_key: StringName = StringName(from)
+	var new_key: StringName = StringName(to)
+	target_line.text = to
+	target_line.set_meta(&"old_value", to)
+
+
+func _do_update_phrase_text(on_key: String, to: String) -> void:
+	var idx: int = -1
+	var erase_btn: Button = null
+	var text_key: LineEdit = null
+	var target_line: TextEdit = null
+	var expand_button: Button = null
+	var edit_button: Button = null
+	var phrase_key: StringName = StringName(on_key)
+	
+	map.set_entry(phrase_key, to)
+	
+	for item in %EntriesContainer.get_children():
+		if item.is_queued_for_deletion():
+			continue
+		var line: LineEdit = item.get_child(1)
+		
+		if line.get_meta(&"old_value") == on_key:
+			idx = item.get_index()
+			erase_btn = item.get_child(0)
+			text_key = item.get_child(1)
+			target_line = item.get_child(2)
+			expand_button = item.get_child(3)
+			edit_button = item.get_child(4)
+			break
+	
+	if idx < 0:
+		return
+	
+	if 0 <= selected_key_index and selected_key_index == idx:
+		save_current_phrase_key()
+		edit_button.icon = get_theme_icon("Edit", "EditorIcons")
+		edit_button.tooltip_text = "Edit Cases"
+		clear_cases()
+		selected_format = ""
+		expand_default_btn.disabled = true
+		selected_key_index = -1
+		default_case_text.clear()
+		default_case_text.editable = false
+		_update_choice_textbox_size(default_case_text)
+		argument_opt_btn.clear()
+		argument_opt_btn.disabled = true
+		new_case_btn.disabled = true
+		
+		erase_btn.disabled = false
+		text_key.editable = true
+		target_line.editable = true
+		expand_button.disabled = false
+		edit_button.disabled = false
+	
+	target_line.text = to
+	target_line.set_meta(&"old_value", to)
+
+
+func _do_update_case_key(from_phrase: String, on_format: String, from_case: String, to_case: String) -> void:
+	var phrase_key: StringName = StringName(from_phrase)
+	var case_result: String = map.get_case(phrase_key, on_format, from_case)
+	map.set_case(phrase_key, on_format, to_case, case_result)
+	map.remove_case(phrase_key, on_format, from_case)
+	
+	if selected_key_index < 0:
+		return
+	
+	for item in %EntriesContainer.get_children():
+		if item.is_queued_for_deletion():
+			continue
+		var line: LineEdit = item.get_child(1)
+		if line.get_meta(&"old_value") == from_phrase:
+			if item.get_index() == selected_key_index:
+				for case_idx in range(1, %CasesContainer.get_child_count()):
+					var case_line: LineEdit = %CasesContainer.get_child(case_idx).get_child(1)
+					if case_line.get_meta(&"old_value") == from_case:
+						case_line.text = to_case
+						case_line.set_meta(&"old_value", to_case)
+						return
+			else:
+				return
+
+
+func _do_update_case_result(from_phrase: String, on_format: String, on_case: String, to_result: String) -> void:
+	var phrase_key: StringName = StringName(from_phrase)
+	map.set_case(phrase_key, on_format, on_case, to_result)
+	
+	if selected_key_index < 0:
+		return
+	
+	for item in %EntriesContainer.get_children():
+		if item.is_queued_for_deletion():
+			continue
+		var line: LineEdit = item.get_child(1)
+		if line.get_meta(&"old_value") == from_phrase:
+			if item.get_index() == selected_key_index:
+				for case_idx in range(1, %CasesContainer.get_child_count()):
+					var case_container: HBoxContainer = %CasesContainer.get_child(case_idx)
+					var case_line: LineEdit = case_container.get_child(1)
+					if case_line.get_meta(&"old_value") == on_case:
+						var case_value: TextEdit = case_container.get_child(2)
+						case_value.text = to_result
+						case_value.set_meta(&"old_value", to_result)
+						return
+			else:
+				return
+
+
+func _do_update_case_default_result(from_phrase: String, on_format: String, to: String) -> void:
+	map.set_case_default(from_phrase, on_format, to)
+	
+	if selected_key_index < 0:
+		return
+	
+	for item in %EntriesContainer.get_children():
+		if item.is_queued_for_deletion():
+			continue
+		var line: LineEdit = item.get_child(1)
+		if line.get_meta(&"old_value") == from_phrase:
+			if item.get_index() == selected_key_index:
+				default_case_text.text = to
+				default_case_text.set_meta(&"old_value", to)
+			break
+
+
+func _do_add_phrase_entry(key: String, text: String, data: Dictionary = {}) -> void:
+	if data.is_empty():
+		map.set_entry(StringName(key), text)
+	else:
+		map._phrases[StringName(key)] = data
+	create_key_text_entry(key, text)
+
+
+func _do_erase_phrase_entry(key: String) -> void:
+	var target_index: int = -1
+	
+	map.erase_entry(StringName(key))
+	
+	for item in %EntriesContainer.get_children():
+		if item.is_queued_for_deletion():
+			continue
+		var line: LineEdit = item.get_child(1)
+		if line.get_meta(&"old_value") == key:
+			target_index = item.get_index()
+			break
+	
+	if target_index < 0:
+		return
+	
+	if selected_key_index == target_index:
+		selected_key_index = -1
+		selected_format = ""
+		clear_cases()
+		default_case_text.clear()
+		default_case_text.editable = false
+		_update_choice_textbox_size(default_case_text)
+		argument_opt_btn.clear()
+		argument_opt_btn.disabled = true
+		new_case_btn.disabled = true
+	
+	erase_key(target_index)
+
+
+func _do_add_case_entry(phrase_key: String, format: String, case_key: String, case_result: String) -> void:
+	map.set_case(StringName(phrase_key), format, case_key, case_result)
+	
+	if selected_key_index < 0:
+		return
+	
+	var current_phrase_line: LineEdit = %EntriesContainer.get_child(selected_key_index).get_child(1)
+	if current_phrase_line.get_meta(&"old_value") != phrase_key:
+		return
+	
+	if argument_opt_btn.selected < 0 or argument_opt_btn.get_item_text(argument_opt_btn.selected) != format:
+		return
+	create_case_entry(case_key, case_result)
+
+
+func _do_erase_case_entry(phrase_key: String, format: String, case_key: String) -> void:
+	map.remove_case(StringName(phrase_key), format, case_key)
+	
+	if selected_key_index < 0:
+		return
+	
+	var current_phrase_line: LineEdit = %EntriesContainer.get_child(selected_key_index).get_child(1)
+	if current_phrase_line.get_meta(&"old_value") != phrase_key:
+		return
+	
+	if argument_opt_btn.selected < 0 or argument_opt_btn.get_item_text(argument_opt_btn.selected) != format:
+		return
+	
+	var target_index: int = -1
+	for case_idx in range(1, %CasesContainer.get_child_count()):
+		var case_node: HBoxContainer = %CasesContainer.get_child(case_idx)
+		if case_node.is_queued_for_deletion():
+			continue
+		var case_line: LineEdit = case_node.get_child(1)
+		if case_line.get_meta(&"old_value") == case_key:
+			target_index = case_idx
+			break
+	
+	if 0 < target_index:
+		erase_case(target_index - 1)
+
+
+func _notification(what: int) -> void:
+	if what == NOTIFICATION_PREDELETE:
+		for id in _open_files:
+			_open_files[id]["undo"].clear_history()
+			_open_files[id]["undo"].free()
+			_open_files[id]["undo"] = null
+			undo = null

--- a/addons/nexus_forge/phrases/phrases_file_tree.gd
+++ b/addons/nexus_forge/phrases/phrases_file_tree.gd
@@ -2,19 +2,19 @@
 extends Tree
 
 
-signal map_close_pressed(map: PhraseMap, save_required: bool)
-signal map_resource_selected(map: PhraseMap)
+signal map_close_pressed(map: int, save_required: bool)
+signal map_resource_selected(map: int)
 
 
 func ready_plugin() -> void:
 	create_item()
 	button_clicked.connect(_on_button_clicked)
-	item_selected.connect(_on_resource_selected)
+	item_mouse_selected.connect(_on_resource_selected)
 
 
-func _on_resource_selected() -> void:
+func _on_resource_selected(mouse_position: Vector2, mouse_button_index: int) -> void:
 	map_resource_selected.emit(
-			get_selected().get_metadata(0)["resource"])
+			get_selected().get_metadata(0)["id"])
 
 
 func _on_button_clicked(item: TreeItem, _column: int, id: int, mouse_button_index: int) -> void:
@@ -24,73 +24,49 @@ func _on_button_clicked(item: TreeItem, _column: int, id: int, mouse_button_inde
 	if id == 0:
 		var meta: Dictionary = item.get_metadata(0)
 		map_close_pressed.emit(
-			meta["resource"],
+			meta["id"],
 			meta["save_required"])
-
-
-func get_open_files() -> Array[String]:
-	var paths: Array[String] = []
-	
-	if get_root() == null:
-		return paths
-	
-	for item in get_root().get_children():
-		paths.append(item.get_metadata(0)["resource"].resource_path)
-	return paths
 
 
 func add_map(resource: PhraseMap, select: bool = false, emit_select: bool = true) -> void:
 	var new_map: TreeItem = get_root().create_child()
 	new_map.set_text(0, resource.resource_path.get_file().get_basename())
 	new_map.set_tooltip_text(0, resource.resource_path)
-	new_map.set_metadata(0, {"resource": resource, "save_required": false})
+	new_map.set_metadata(0, {"id": resource.get_instance_id(), "save_required": false})
 	new_map.add_button(0, get_theme_icon("GuiClose", "EditorIcons"), 0, false, "Close file")
 	
 	if select:
+		new_map.select(0)
 		if emit_select:
-			new_map.select(0)
-		else:
-			item_selected.disconnect(_on_resource_selected)
-			new_map.select(0)
-			item_selected.connect(_on_resource_selected)
+			map_resource_selected.emit(resource.get_instance_id())
 
 
-func has_map(map: PhraseMap) -> bool:
+func has_map(map: int) -> bool:
 	for item in get_root().get_children():
-		if item.get_metadata(0)["resource"] == map:
+		if item.get_metadata(0)["id"] == map:
 			return true
 	return false
 
 
-func remove_map(resource: PhraseMap) -> void:
+func remove_map(resource: int) -> void:
 	for item in get_root().get_children():
-		if item.get_metadata(0)["resource"] == resource:
+		if item.get_metadata(0)["id"] == resource:
 			item.free()
 			return
 
 
-func select_map(resource: PhraseMap, emit_select: bool = true) -> void:
+func select_map(id: int, emit_select: bool = true) -> void:
 	for item in get_root().get_children():
-		if item.get_metadata(0)["resource"] == resource:
+		if item.get_metadata(0)["id"] == id:
+			item.select(0)
 			if emit_select:
-				item.select(0)
-			else:
-				item_selected.disconnect(_on_resource_selected)
-				item.select(0)
-				item_selected.connect(_on_resource_selected)
+				map_resource_selected.emit(id)
 			return
 
 
-func requires_save(resource: PhraseMap) -> bool:
+func set_save_required(resource: int, save_required: bool) -> void:
 	for item in get_root().get_children():
-		if item.get_metadata(0)["resource"] == resource:
-			return item.get_metadata(0)["save_required"]
-	return false
-
-
-func set_save_required(resource: PhraseMap, save_required: bool) -> void:
-	for item in get_root().get_children():
-		if item.get_metadata(0)["resource"] == resource:
+		if item.get_metadata(0)["id"] == resource:
 			if save_required != item.get_metadata(0)["save_required"]:
 				if save_required:
 					item.set_text(0, item.get_text(0) + "*")
@@ -109,18 +85,3 @@ func set_save_required_all(save_required: bool) -> void:
 		else:
 			item.set_text(0, item.get_text(0).trim_suffix("*"))
 		item.get_metadata(0)["save_required"] = save_required
-
-
-func get_unsaved_resources() -> Array[PhraseMap]:
-	var unsaved_resources: Array[PhraseMap] = []
-	for item in get_root().get_children():
-		if item.get_metadata(0)["save_required"]:
-			unsaved_resources.append(item.get_metadata(0)["resource"])
-	return unsaved_resources
-
-
-func has_unsaved() -> bool:
-	for item in get_root().get_children():
-		if item.get_metadata(0)["save_required"]:
-			return true
-	return false

--- a/addons/nexus_forge/plugin.cfg
+++ b/addons/nexus_forge/plugin.cfg
@@ -3,5 +3,5 @@
 name="Nexus Forge"
 description="A headless modular toolset plugin for Godot"
 author="Ketei"
-version="0.7.1-beta"
+version="0.8.0-beta"
 script="plugin.gd"

--- a/addons/nexus_forge/plugin.gd
+++ b/addons/nexus_forge/plugin.gd
@@ -202,6 +202,7 @@ func _get_plugin_name() -> String:
 func _make_visible(visible):
 	if editor_view != null:
 		editor_view.visible = visible
+		
 
 
 func _enable_plugin() -> void:

--- a/addons/nexus_forge/plugin.gd
+++ b/addons/nexus_forge/plugin.gd
@@ -547,7 +547,7 @@ func _handles(object: Object) -> bool:
 
 func _edit(object: Object) -> void:
 	if _editor_ready() and object != null:
-		_make_visible(true)
+		EditorInterface.set_main_screen_editor(PLUGIN_NAME)
 		editor_view.handle_resource(object)
 
 

--- a/addons/nexus_forge/quests/new_odyssey_script.gd
+++ b/addons/nexus_forge/quests/new_odyssey_script.gd
@@ -85,61 +85,7 @@ static func update_script_path(quest: bool = true, stage: bool = true, objective
 			break
 
 
-func _ready() -> void:
-	set_process_input(false)
-
-
-func _input(event: InputEvent) -> void:
-	if not is_visible_in_tree():
-		return
-	
-	if event is InputEventKey:
-		if event.echo or not event.pressed or not event.ctrl_pressed:
-			return
-		
-		var current_focus: Control = get_viewport().gui_get_focus_owner()
-		
-		if current_focus != null:
-			if current_focus is LineEdit:
-				if current_focus.is_editing():
-					return
-			elif current_focus is TextEdit:
-				return
-		
-		if event.keycode == KEY_Z:
-			if event.shift_pressed:
-				if undo.has_redo():
-					var action_name: String = undo.get_action_name(undo.get_current_action() + 1)
-					undo.redo()
-					NFPluginGameHandler._log_msg(
-						"",
-						"Redo: " + action_name,
-						NFPluginGameHandler._LogLevel.EDITOR)
-					_on_something_changed()
-			else:
-				if undo.has_undo():
-					var action_name: String = undo.get_current_action_name()
-					undo.undo()
-					NFPluginGameHandler._log_msg(
-						"",
-						"Undo: " + action_name,
-						NFPluginGameHandler._LogLevel.EDITOR)
-					_on_something_changed()
-			get_viewport().set_input_as_handled()
-		elif event.keycode == KEY_Y and not event.shift_pressed:
-			if undo.has_redo():
-				var action_name: String = undo.get_action_name(undo.get_current_action() + 1)
-				undo.redo()
-				NFPluginGameHandler._log_msg(
-					"",
-					"Redo: " + action_name,
-					NFPluginGameHandler._LogLevel.EDITOR)
-				_on_something_changed()
-			get_viewport().set_input_as_handled()
-
-
 func ready_plugin() -> void:
-	set_process_input(true)
 	obj_req_tree.ready_plugin()
 	files_tree.ready_plugin()
 	quest_tree.ready_plugin()
@@ -247,6 +193,38 @@ func ready_plugin() -> void:
 	obj_req_tree.data_updated.connect(_on_objective_data_updated)
 	obj_req_tree.data_erased.connect(_on_objective_data_erased)
 	obj_req_tree.data_operator_changed.connect(_on_data_data_operator_changed)
+
+
+func can_undo() -> bool:
+	if is_instance_valid(undo):
+		return undo.has_undo()
+	return false
+
+
+func can_redo() -> bool:
+	if is_instance_valid(undo):
+		return undo.has_redo()
+	return false
+
+
+func do_undo() -> void:
+	var action_name: String = undo.get_current_action_name()
+	undo.undo()
+	NFPluginGameHandler._log_msg(
+		"",
+		"Undo: " + action_name,
+		NFPluginGameHandler._LogLevel.EDITOR)
+	_on_something_changed()
+
+
+func do_redo() -> void:
+	var action_name: String = undo.get_action_name(undo.get_current_action() + 1)
+	undo.redo()
+	NFPluginGameHandler._log_msg(
+		"",
+		"Redo: " + action_name,
+		NFPluginGameHandler._LogLevel.EDITOR)
+	_on_something_changed()
 
 
 func filesystem_resource_removed(quest: Quest) -> void:

--- a/addons/nexus_forge/recipes/crafting_script.gd
+++ b/addons/nexus_forge/recipes/crafting_script.gd
@@ -51,54 +51,9 @@ func _input(event: InputEvent) -> void:
 			return
 		
 		if event.keycode == KEY_DELETE and not event.ctrl_pressed and not event.shift_pressed:
-			
 			if not active_recipe.is_empty():
 				recipe_tree.remove_recipe(active_recipe)
 				_on_recipe_erased(active_recipe)
-			get_viewport().set_input_as_handled()
-			return
-		
-		if not event.ctrl_pressed:
-			return
-		
-		var current_focus: Control = get_viewport().gui_get_focus_owner()
-		
-		if current_focus != null:
-			if current_focus is LineEdit:
-				if current_focus.is_editing():
-					return
-			elif current_focus is TextEdit:
-				return
-		
-		if event.keycode == KEY_Z:
-			if event.shift_pressed:
-				if undo.has_redo():
-					var action_name: String = undo.get_action_name(undo.get_current_action() + 1)
-					undo.redo()
-					NFPluginGameHandler._log_msg(
-						"",
-						"Redo: " + action_name,
-						NFPluginGameHandler._LogLevel.EDITOR)
-					_something_changed()
-			else:
-				if undo.has_undo():
-					var action_name: String = undo.get_current_action_name()
-					undo.undo()
-					NFPluginGameHandler._log_msg(
-						"",
-						"Undo: " + action_name,
-						NFPluginGameHandler._LogLevel.EDITOR)
-					_something_changed()
-			get_viewport().set_input_as_handled()
-		elif event.keycode == KEY_Y and not event.shift_pressed:
-			if undo.has_redo():
-				var action_name: String = undo.get_action_name(undo.get_current_action() + 1)
-				undo.redo()
-				NFPluginGameHandler._log_msg(
-						"",
-						"Redo: " + action_name,
-						NFPluginGameHandler._LogLevel.EDITOR)
-				_something_changed()
 			get_viewport().set_input_as_handled()
 
 
@@ -159,6 +114,39 @@ func ready_plugin() -> void:
 	recipe_output_tree.metadata_removed.connect(_on_recipe_ingredient_metadata_removed.bind(false))
 	recipe_output_tree.metadata_changed.connect(_on_ingredient_metadata_changed.bind(false))
 	recipe_output_tree.metadata_renamed.connect(_on_ingredient_metadata_renamed.bind(false))
+
+
+func can_undo() -> bool:
+	if is_instance_valid(undo):
+		return undo.has_undo()
+	return false
+
+
+func can_redo() -> bool:
+	if is_instance_valid(undo):
+		return undo.has_redo()
+	return false
+
+
+func do_undo() -> void:
+	var action_name: String = undo.get_current_action_name()
+	undo.undo()
+	NFPluginGameHandler._log_msg(
+		"",
+		"Undo: " + action_name,
+		NFPluginGameHandler._LogLevel.EDITOR)
+	_something_changed()
+
+
+func do_redo() -> void:
+	var action_name: String = undo.get_action_name(undo.get_current_action() + 1)
+	undo.redo()
+	NFPluginGameHandler._log_msg(
+			"",
+			"Redo: " + action_name,
+			NFPluginGameHandler._LogLevel.EDITOR)
+	_something_changed()
+
 
 
 func _on_recipe_lnedt_text_changed(text: String) -> void:

--- a/addons/nexus_forge/resources/dialog_storage/dialog_storage_editor.gd
+++ b/addons/nexus_forge/resources/dialog_storage/dialog_storage_editor.gd
@@ -8,6 +8,8 @@ extends DiscourseDialog
 ## [ReleaseDiscourseDialog] and the original files are NOT included.
 
 
+static var regex_search: RegEx
+
 ## Offset for the [GraphEdit] in Discourse.
 var scroll_offset: Vector2 = Vector2.ZERO:
 	set(new_scroll):
@@ -113,6 +115,26 @@ var collapsed_state: Dictionary[String, bool] = {}
 var _id_map: Dictionary[StringName, StringName] = {}
 
 
+static func _static_init() -> void:
+	regex_search = RegEx.new()
+	regex_search.compile("\\{[\\$\\!][^\\s\\}]+\\}")
+
+
+## Returns an array with all the format arguments of the prase [param phrase_text].[br]
+## It'll only look for format arguments that start with $ or !.
+static func get_phrase_arguments(phrase_text: String, trim_brackets: bool = false) -> Array[String]:
+	var all_arguments: Array[String] = []
+	
+	if trim_brackets:
+		for regex_match in regex_search.search_all(phrase_text): # $variable
+			all_arguments.append(regex_match.get_string().trim_prefix("{").trim_suffix("}"))
+	else:
+		for regex_match in regex_search.search_all(phrase_text): # $variable
+			all_arguments.append(regex_match.get_string())
+	
+	return all_arguments
+
+
 ## Returns the text of a localized string.
 func get_format_string(key: String, locale: String) -> String:
 	locale = TranslationServer.standardize_locale(locale)
@@ -165,13 +187,15 @@ func get_editor_localized_strings(locale_code: String) -> Dictionary[String, Dic
 func set_format_string(key: String, text: String, locale: String) -> void:
 	locale = TranslationServer.standardize_locale(locale)
 	
-	var text_set: bool = DictUtils.set_nested_value(format_strings, [key, locale, "base_string"], text, false)
+	if not format_strings.has(key) or locale.is_empty():
+		return
 	
-	if not text_set:
-		DictUtils.set_nested_value(
-					format_strings,
-					[key, locale],
-					{"base_string": text, "format": {}})
+	if not format_strings[key].has(locale):
+		format_strings[key][locale] = {
+			"base_string": "",
+			"format": {}}
+	
+	DictUtils.set_nested_value(format_strings, [key, locale, "base_string"], text, false)
 
 
 ## Checks if the format key exists in the given key and locale. If it doesn't it'll
@@ -195,8 +219,14 @@ func validate_format_string_format(key: String, locale: String, format: String) 
 
 func set_format_string_case(key: String, locale: String, format: String, case: String, value: String) -> void:
 	locale = TranslationServer.standardize_locale(locale)
-	if not DictUtils.has_nested_path(format_strings, [key, locale]):
+	
+	if locale.is_empty() or not format_strings.has(key):
 		return
+	
+	if not format_strings[key].has(locale):
+		format_strings[key][locale] = {
+			"base_string": "",
+			"format": {}}
 	
 	if not format_strings[key][locale]["format"].has(format):
 		format_strings[key][locale]["format"][format] = {
@@ -229,8 +259,14 @@ func get_format_string_cases(key: String, locale: String, format: String) -> Arr
 ## Sets the default case from a localized string with the given key.
 func set_format_string_default_case(key: String, locale: String, format: String, default_text: String) -> void:
 	locale = TranslationServer.standardize_locale(locale)
-	if not DictUtils.has_nested_path(format_strings, [key, locale]):
+	
+	if locale.is_empty() or not format_strings.has(key):
 		return
+	
+	if not format_strings[key].has(locale):
+		format_strings[key][locale] = {
+			"base_string": "",
+			"format": {}}
 	
 	if not format_strings[key][locale]["format"].has(format):
 		format_strings[key][locale]["format"][format] = {
@@ -1232,25 +1268,6 @@ func split_path_variable(path: String) -> Array[StringName]:
 	if split.size() != 2:
 		path_array.resize(2)
 	return path_array
-
-
-## Returns an array with all the format arguments of the prase [param phrase_text].[br]
-## It'll only look for format arguments that start with $ or !.
-static func get_phrase_arguments(phrase_text: String, trim_brackets: bool = false) -> Array[String]:
-	var all_arguments: Array[String] = []
-	
-	var regex_search: RegEx = RegEx.new()
-	
-	regex_search.compile("\\{[\\$\\!][^\\s\\}]+\\}")
-	
-	if trim_brackets:
-		for regex_match in regex_search.search_all(phrase_text): # $variable
-			all_arguments.append(regex_match.get_string().trim_prefix("{").trim_suffix("}"))
-	else:
-		for regex_match in regex_search.search_all(phrase_text): # $variable
-			all_arguments.append(regex_match.get_string())
-	
-	return all_arguments
 
 
 ## Adds a locale to the locale map. The locale map is used to track which

--- a/addons/nexus_forge/resources/localization/phrase_map.gd
+++ b/addons/nexus_forge/resources/localization/phrase_map.gd
@@ -233,6 +233,20 @@ func set_case(key: StringName, format: String, case: String, value: String) -> v
 			value)
 
 
+## Removes the [param case] from the [param format] of the phrase with the
+## given [param key].
+func remove_case(key: StringName, format: String, case: String) -> void:
+	if not _phrases.has(key):
+		return
+	
+	var dict: Dictionary = DictUtils.get_nested_value(
+			_phrases,
+			[key, "formats", format, "cases"],
+			{},
+			true)
+	dict.erase(case)
+
+
 ## Sets the default case on the phrase [param key] of the argument
 ## [param on_argument] to [param default].
 func set_case_default(key: StringName, format: String, default: String) -> void:

--- a/addons/nexus_forge/resources/localization/phrase_map.gd
+++ b/addons/nexus_forge/resources/localization/phrase_map.gd
@@ -160,12 +160,21 @@ func entries() -> Array[StringName]:
 func set_entry(key: StringName, text: String) -> void:
 	var formats: Dictionary = {}
 	var entry_exists: bool = _phrases.has(key)
+	
 	for format in get_valid_formats(text):
 		var default: String = ""
 		var cases: Dictionary[String, String] = {}
 		if entry_exists and _phrases[key]["formats"].has(format):
-			default = _phrases[key]["formats"][format]["default"]
-			cases.assign(_phrases[key]["formats"][format]["cases"])
+			default = DictUtils.get_nested_value(
+					_phrases,
+					[key, "formats", format, "default"],
+					"",
+					true)
+			cases.assign(DictUtils.get_nested_value(
+					_phrases,
+					[key, "formats", format, "cases"],
+					{},
+					true))
 		
 		formats[format] = {
 			"default": default,
@@ -227,10 +236,16 @@ func set_case(key: StringName, format: String, case: String, value: String) -> v
 	if not _phrases.has(key):
 		return
 	
+	if not _phrases[key]["formats"].has(format):
+		_phrases[key]["formats"][format] = {
+			"default": "",
+			"cases": DictUtils.create_typed(TYPE_STRING, TYPE_STRING)}
+	
 	DictUtils.set_nested_value(
 			_phrases,
 			[key, "formats", format, "cases", case],
-			value)
+			value,
+			false)
 
 
 ## Removes the [param case] from the [param format] of the phrase with the
@@ -253,10 +268,16 @@ func set_case_default(key: StringName, format: String, default: String) -> void:
 	if not _phrases.has(key):
 		return
 	
+	if not _phrases[key]["formats"].has(format):
+		_phrases[key]["formats"][format] = {
+			"default": "",
+			"cases": DictUtils.create_typed(TYPE_STRING, TYPE_STRING)}
+	
 	DictUtils.set_nested_value(
 			_phrases,
 			[key, "formats", format, "default"],
-			default)
+			default,
+			false)
 
 
 ## Clears the custom cases of the [param format] from the phrase

--- a/addons/nexus_forge/species/races_main_script.gd
+++ b/addons/nexus_forge/species/races_main_script.gd
@@ -46,12 +46,7 @@ var signal_change: bool = false
 @onready var hybrid_b: Label = $RacesContainer/RacesBasicSplit/BasicDataContainer/HybridInfoContainer/HybridB
 
 
-func _ready() -> void:
-	set_process_input(false)
-
-
 func ready_plugin() -> void:
-	set_process_input(true)
 	undo = UndoRedo.new()
 	undo.max_steps = UNDO_MAX_STEPS
 	race_data_tree.undo_redo_steps = UNDO_MAX_STEPS
@@ -107,53 +102,36 @@ func ready_plugin() -> void:
 	dom_opt_btn.item_selected.connect(_on_dominant_gene_selected)
 
 
-func _input(event: InputEvent) -> void:
-	if not is_visible_in_tree():
-		return
-	
-	if event is InputEventKey:
-		if event.echo or not event.pressed or not event.ctrl_pressed:
-			return
-		
-		var current_focus: Control = get_viewport().gui_get_focus_owner()
-		
-		if current_focus != null:
-			if current_focus is LineEdit:
-				if current_focus.is_editing():
-					return
-			elif current_focus is TextEdit:
-				return
-		
-		if event.keycode == KEY_Z:
-			if event.shift_pressed:
-				if undo.has_redo():
-					var action_name: String = undo.get_action_name(undo.get_current_action() + 1)
-					undo.redo()
-					NFPluginGameHandler._log_msg(
-							"",
-							"Redo: " + action_name,
-							NFPluginGameHandler._LogLevel.EDITOR)
-					_on_something_changed()
-			else:
-				if undo.has_undo():
-					var action_name: String = undo.get_action_name(undo.get_current_action())
-					undo.undo()
-					NFPluginGameHandler._log_msg(
-							"",
-							"Undo: " + action_name,
-							NFPluginGameHandler._LogLevel.EDITOR)
-					_on_something_changed()
-			get_viewport().set_input_as_handled()
-		if event.keycode == KEY_Y and not event.shift_pressed:
-			if undo.has_redo():
-				var action_name: String = undo.get_current_action_name()
-				undo.redo()
-				NFPluginGameHandler._log_msg(
-							"",
-							"Redo: " + action_name,
-							NFPluginGameHandler._LogLevel.EDITOR)
-				_on_something_changed()
-			get_viewport().set_input_as_handled()
+func can_undo() -> bool:
+	if is_instance_valid(undo):
+		return undo.has_undo()
+	return false
+
+
+func can_redo() -> bool:
+	if is_instance_valid(undo):
+		return undo.has_redo()
+	return false
+
+
+func do_undo() -> void:
+	var action_name: String = undo.get_action_name(undo.get_current_action())
+	undo.undo()
+	NFPluginGameHandler._log_msg(
+			"",
+			"Undo: " + action_name,
+			NFPluginGameHandler._LogLevel.EDITOR)
+	_on_something_changed()
+
+
+func do_redo() -> void:
+	var action_name: String = undo.get_current_action_name()
+	undo.redo()
+	NFPluginGameHandler._log_msg(
+				"",
+				"Redo: " + action_name,
+				NFPluginGameHandler._LogLevel.EDITOR)
+	_on_something_changed()
 
 
 func _on_data_tree_data_changed() -> void:

--- a/addons/nexus_forge/talents/talents_main_script.gd
+++ b/addons/nexus_forge/talents/talents_main_script.gd
@@ -54,12 +54,7 @@ var undo: UndoRedo = null
 @onready var edit_traits_btn: Button = $MainContainer/TraitsPanel/TraitsContainerContainer/TraitSelectContainer/TraitContainer/EditTraitsBtn
 
 
-func _ready() -> void:
-	set_process_input(false)
-
-
 func ready_plugin(stats_enabled: bool, skills_enabled: bool, traits_enabled: bool) -> void:
-	set_process_input(true)
 	undo = UndoRedo.new()
 	undo.max_steps = UNDO_MAX_STEPS
 	
@@ -153,50 +148,34 @@ func ready_plugin(stats_enabled: bool, skills_enabled: bool, traits_enabled: boo
 		trait_data_tree.data_changed.connect(_on_data_tree_updated.bind(2))
 
 
-func _input(event: InputEvent) -> void:
-	if not is_visible_in_tree():
-		return
-	
-	if event is InputEventKey:
-		if event.echo or not event.pressed or not event.ctrl_pressed:
-			return
-		
-		var current_focus: Control = get_viewport().gui_get_focus_owner()
-		
-		if current_focus != null:
-			if current_focus is LineEdit:
-				if current_focus.is_editing():
-					return
-			elif current_focus is TextEdit:
-				return
-		
-		if event.keycode == KEY_Z:
-			if event.shift_pressed:
-				if undo.has_redo():
-					var action_name: String = undo.get_action_name(undo.get_current_action() + 1)
-					undo.redo()
-					NFPluginGameHandler._log_msg(
-							"",
-							"Redo: " + action_name,
-							NFPluginGameHandler._LogLevel.EDITOR)
-			else:
-				if undo.has_undo():
-					var action_name: String = undo.get_current_action_name()
-					undo.undo()
-					NFPluginGameHandler._log_msg(
-							"",
-							"Undo: " + action_name,
-							NFPluginGameHandler._LogLevel.EDITOR)
-			get_viewport().set_input_as_handled()
-		elif event.keycode == KEY_Y and not event.shift_pressed:
-			if undo.has_redo():
-				var action_name: String = undo.get_action_name(undo.get_current_action() + 1)
-				undo.redo()
-				NFPluginGameHandler._log_msg(
-						"",
-						"Redo: " + action_name,
-						NFPluginGameHandler._LogLevel.EDITOR)
-			get_viewport().set_input_as_handled()
+func can_undo() -> bool:
+	if is_instance_valid(undo):
+		return undo.has_undo()
+	return false
+
+
+func can_redo() -> bool:
+	if is_instance_valid(undo):
+		return undo.has_redo()
+	return false
+
+
+func do_undo() -> void:
+	var action_name: String = undo.get_current_action_name()
+	undo.undo()
+	NFPluginGameHandler._log_msg(
+			"",
+			"Undo: " + action_name,
+			NFPluginGameHandler._LogLevel.EDITOR)
+
+
+func do_redo() -> void:
+	var action_name: String = undo.get_action_name(undo.get_current_action() + 1)
+	undo.redo()
+	NFPluginGameHandler._log_msg(
+			"",
+			"Redo: " + action_name,
+			NFPluginGameHandler._LogLevel.EDITOR)
 
 
 func _on_edit_skillset_pressed() -> void:
@@ -381,9 +360,17 @@ func _on_add_skill_data_pressed(data_name: String, data: Variant) -> void:
 	skill_data_tree.add_data(data_name, data)
 	if skill_data_tree.has_undo():
 		undo.create_action("Data Changed")
-		undo.add_do_method(skill_data_tree.redo)
-		undo.add_undo_method(skill_data_tree.undo)
+		undo.add_do_method(_do_skill_data_tree_undoredo.bind(false))
+		undo.add_undo_method(_do_skill_data_tree_undoredo.bind(true))
 		undo.commit_action(false)
+	_on_skills_changed()
+
+
+func _do_skill_data_tree_undoredo(is_undo: bool) -> void:
+	if is_undo:
+		skill_data_tree.undo()
+	else:
+		skill_data_tree.redo()
 	_on_skills_changed()
 
 
@@ -650,9 +637,17 @@ func _on_add_trait_data_pressed(data_name: String, data: Variant) -> void:
 	trait_data_tree.add_data(data_name, data)
 	if trait_data_tree.has_undo():
 		undo.create_action("Data Changed")
-		undo.add_do_method(trait_data_tree.redo)
-		undo.add_undo_method(trait_data_tree.undo)
+		undo.add_do_method(_do_trait_data_tree_undoredo.bind(false))
+		undo.add_undo_method(_do_trait_data_tree_undoredo.bind(true))
 		undo.commit_action(false)
+	_on_traits_changed()
+
+
+func _do_trait_data_tree_undoredo(is_undo: bool) -> void:
+	if is_undo:
+		trait_data_tree.undo()
+	else:
+		trait_data_tree.redo()
 	_on_traits_changed()
 
 
@@ -928,9 +923,17 @@ func _on_add_stat_data_pressed(data_name: String, data: Variant) -> void:
 	stat_data_tree.add_data(data_name, data)
 	if stat_data_tree.has_undo():
 		undo.create_action("Data Changed")
-		undo.add_do_method(stat_data_tree.redo)
-		undo.add_undo_method(stat_data_tree.undo)
+		undo.add_do_method(_do_stat_data_tree_undoredo.bind(false))
+		undo.add_undo_method(_do_stat_data_tree_undoredo.bind(true))
 		undo.commit_action(false)
+	_on_stats_changed()
+
+
+func _do_stat_data_tree_undoredo(is_undo: bool) -> void:
+	if is_undo:
+		stat_data_tree.undo()
+	else:
+		stat_data_tree.redo()
 	_on_stats_changed()
 
 

--- a/addons/nexus_forge/variables/variables_main_script.gd
+++ b/addons/nexus_forge/variables/variables_main_script.gd
@@ -36,59 +36,7 @@ var undo: UndoRedo = null
 @onready var current_folder_label: Label = $MainSplit/VBoxContainer2/TitleContainer/FolderPathContainer/CurrentFolderLabel
 
 
-func _ready() -> void:
-	set_process_input(false)
-
-
-func _input(event: InputEvent) -> void:
-	if event is not InputEventKey:
-		return
-	
-	if not is_visible_in_tree() or event.echo or not event.pressed or not event.ctrl_pressed:
-		return
-	
-	var focused_node: Control = get_viewport().gui_get_focus_owner()
-	if focused_node != null:
-		if focused_node is LineEdit:
-			if focused_node.is_editing():
-				return
-			elif focused_node is TextEdit:
-				return
-	
-	if event.keycode == KEY_Z:
-		if event.shift_pressed:
-			if undo.has_redo():
-				var action_name: String = undo.get_action_name(undo.get_current_action() + 1)
-				undo.redo()
-				NFPluginGameHandler._log_msg(
-						"",
-						"Redo: " + action_name,
-						NFPluginGameHandler._LogLevel.EDITOR)
-				on_something_changed()
-		else:
-			if undo.has_undo():
-				var action_name: String = undo.get_current_action_name()
-				undo.undo()
-				NFPluginGameHandler._log_msg(
-						"",
-						"Undo: " + action_name,
-						NFPluginGameHandler._LogLevel.EDITOR)
-				on_something_changed()
-		get_viewport().set_input_as_handled()
-	elif event.keycode == KEY_Y and not event.shift_pressed:
-		if undo.has_redo():
-			var action_name: String = undo.get_action_name(undo.get_current_action() + 1)
-			undo.redo()
-			NFPluginGameHandler._log_msg(
-					"",
-					"Redo: " + action_name,
-					NFPluginGameHandler._LogLevel.EDITOR)
-			on_something_changed()
-		get_viewport().set_input_as_handled()
-
-
 func ready_plugin() -> void:
-	set_process_input(true)
 	folders_tree.ready_plugin()
 	variables_tree.ready_plugin()
 	undo = UndoRedo.new()
@@ -122,6 +70,39 @@ func ready_plugin() -> void:
 	
 	folders_tree.folder_deleted.connect(_on_folder_deleted)
 	folders_tree.folder_renamed.connect(_on_folder_renamed)
+
+
+func can_undo() -> bool:
+	if is_instance_valid(undo):
+		return undo.has_undo()
+	return false
+
+
+func can_redo() -> bool:
+	if is_instance_valid(undo):
+		return undo.has_redo()
+	return false
+
+
+func do_undo() -> void:
+	var action_name: String = undo.get_current_action_name()
+	undo.undo()
+	NFPluginGameHandler._log_msg(
+			"",
+			"Undo: " + action_name,
+			NFPluginGameHandler._LogLevel.EDITOR)
+	on_something_changed()
+
+
+func do_redo() -> void:
+	var action_name: String = undo.get_action_name(undo.get_current_action() + 1)
+	undo.redo()
+	NFPluginGameHandler._log_msg(
+			"",
+			"Redo: " + action_name,
+			NFPluginGameHandler._LogLevel.EDITOR)
+	on_something_changed()
+
 
 
 func reload_resource(first_load: bool = false) -> void:


### PR DESCRIPTION
Last UndoRedo module implemented.
Tested & fixed some stuff. Seems stable.

v0.7.1 -> v0.8.0 changes:

- Added UndoRedo for Phrase Maps
- Added missing UndoRedo actions on Discourse when creating phrase keys and their cases

- Fixed an obscure issue that sometimes caused Nexus Forge to appear in "split-screen" at the bottom side of Godot.
- Fixed adding data to an item category not triggering the unsaved flag
- Fixed an error that could occour if the PhrasesAPI contained a singleton call or any other that requires a running game.
- Fixed an issue that prevented undo-redo from firing when focusing a disabled TextEdit
- Fixed phrase keys & cases not correcting their entry key after editing
- Fixed new case button remaining enabled after closing a phrase map
- Fixed an issue that happened when deleting a phrase case due to using wrong indexes

- Changed how discourse & phrase map keys & cases function. Now instead of highlighting an error, it will automatically fix it.
- Changed how discourse editor & phrase map cases registration work. Now when registering a case, the full structure will be correctly built.
- Changed how discourse editor & phrase map phrases are registered on editor dialogue resource files to create complete data.